### PR TITLE
update docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker run -it --rm -p 4000:4000 \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --name opencode \
   ghcr.io/sst/opencode:latest \
-  /bin/sh -c "opencode serve --port 4000 --hostname 0.0.0.0 & exec bash"
+  serve --port 4000 --hostname 0.0.0.0
 ```
 
 > **Note**: Omit the git configuration mounts if you do not need git setup:


### PR DESCRIPTION
> Removed unnecessary command prefix from opencode serve command.

The image `ghcr.io/sst/opencode:latest` already has an `ENTRYPOINT`.

```Dockerfile
ENTRYPOINT ["opencode"]
```

see https://github.com/sst/opencode/blob/dev/packages/opencode/Dockerfile

that's why it fails