### PR TITLE
Fix Windows compatibility issues

### DIFF
--- a/packages/cli/src/opencode.ts
+++ b/packages/cli/src/opencode.ts
@@ -101,6 +101,7 @@ export async function startOpencodeServer(
   const proc = spawn(command, args, {
     cwd: config.directory,
     stdio: ["ignore", "pipe", "pipe"],
+    shell: platform() === "win32",
     env: {
       ...process.env,
       FORCE_COLOR: "1",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -77,7 +77,7 @@ function ensureNodeModulesSymlink(modulesDir: string): void {
         return;
       }
     }
-    symlinkSync("_modules", nodeModulesPath, "dir");
+    symlinkSync("_modules", nodeModulesPath, platform() === "win32" ? "junction" : "dir");
   } catch {}
 }
 


### PR DESCRIPTION
## Summary
This PR fixes two critical issues encountered when running `openportal` on Windows:

1. **Process Spawning**: Fixed an `EINVAL` error when starting the OpenCode server by enabling `shell: true` on Windows.
2. **Symlink Resolution**: Fixed dependency resolution failures in the Web UI by using directory junctions instead of standard symlinks on Windows.

## Changes
- Modified `packages/cli/src/opencode.ts` to use `shell: true` when spawning `opencode` on Windows.
- Modified `packages/cli/src/server.ts` to use `junction` type for `symlinkSync` on Windows.

Verified on Windows 10/11.