### PR TITLE
Fix OpenCode CLI mount and alias

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "bin": {
-    "portal": "./src/index.ts"
+    "portal": "./src/index.ts",
+    "cli-new": "./src/index.ts"
   },
   "scripts": {
     "dev": "bun run src/index.ts",


### PR DESCRIPTION
- Add cli-new alias to the CLI binary.\n- Mount the target directory to the same path in the container and set workdir.\n- Pass serve and fix docker run arg splitting.