### PR TITLE
CLI: random host port for OpenCode

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
-    "commander": "^14.0.0"
+    "commander": "^14.0.0",
+    "get-port-please": "^3.2.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.5",


### PR DESCRIPTION
Use get-port-please to allocate a random host port for the OpenCode container. Map it to port 4096 and log the chosen host port.