### PR TITLE
fix: add remark-gfm for markdown table rendering

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "react-aria-components": "^1.14.0",
     "react-dom": "^19.2.1",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "swr": "^2.3.7",
     "tailwind-merge": "^3.4.0",

--- a/apps/web/src/pages/session/[id].tsx
+++ b/apps/web/src/pages/session/[id].tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback, memo, useMemo } from "react";
 import { useRouter } from "next/router";
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import NumberFlow from "@number-flow/react";
 import AppLayout from "@/layouts/app-layout";
 import { ModelSelect } from "@/components/model-select";
@@ -233,7 +234,7 @@ const MessageItem = memo(function MessageItem({
             <div
               className={`prose prose-sm dark:prose-invert max-w-none overflow-x-hidden ${!isAssistant ? "text-muted-fg" : ""}`}
             >
-              <Markdown>{textContent}</Markdown>
+              <Markdown remarkPlugins={[remarkGfm]}>{textContent}</Markdown>
             </div>
           </div>
         </div>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -252,6 +252,47 @@ body {
   }
 }
 
+/* Markdown prose table styling */
+.prose table {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.prose thead {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.prose tbody {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.prose tr {
+  display: table-row;
+}
+
+.prose th,
+.prose td {
+  display: table-cell;
+  white-space: normal;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+}
+
+.prose th {
+  background-color: var(--muted);
+  font-weight: 600;
+}
+
+.prose tbody tr:nth-child(even) {
+  background-color: var(--muted);
+}
+
 @utility touch-target {
   position: relative;
   &::before {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "react-aria-components": "^1.14.0",
         "react-dom": "^19.2.1",
         "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "swr": "^2.3.7",
         "tailwind-merge": "^3.4.0",
@@ -11971,7 +11972,7 @@
     },
     "packages/cli": {
       "name": "openportal",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.1.0"


### PR DESCRIPTION
## Summary
- Install `remark-gfm` plugin for GitHub Flavored Markdown table support
- Add `remarkPlugins` prop to `<Markdown>` component
- Add table styling in `globals.css` (horizontal scroll, borders, zebra stripes)

## Changes
- `apps/web/package.json` - added remark-gfm dependency
- `apps/web/src/pages/session/[id].tsx` - import and use remark-gfm plugin
- `apps/web/src/styles/globals.css` - table overflow and styling

## Screenshots

### Before
<img width="2302" height="1012" alt="pr-15-before" src="https://github.com/user-attachments/assets/1b4a94bd-9d12-44ee-8b27-6e2fa2af0721" />

### After
<img width="2302" height="1258" alt="pr-15-after" src="https://github.com/user-attachments/assets/c55127c2-e084-4327-b11e-a34f8bab366d" />
