### PR TITLE
fix: hide model selector when agent is selected

### DIFF
--- a/apps/web/src/routes/_app/session/$id.tsx
+++ b/apps/web/src/routes/_app/session/$id.tsx
@@ -322,7 +322,7 @@ function SessionPage() {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               text: messageText,
-              model: selectedModel,
+              model: selectedAgent ? undefined : selectedModel,
               agent: selectedAgent,
             }),
           },
@@ -540,7 +540,7 @@ function SessionPage() {
               <AgentSelect sessionId={sessionId} />
             </div>
             <div className="flex items-center justify-between gap-2 sm:justify-end">
-              <ModelSelect />
+              {!selectedAgent && <ModelSelect />}
               <Button
                 type="submit"
                 isDisabled={!input.trim()}

--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
     },
     "packages/cli": {
       "name": "openportal",
-      "version": "0.1.23",
+      "version": "0.1.25",
       "bin": {
         "openportal": "./dist/index.js",
       },


### PR DESCRIPTION
## Summary

- Hide the model selector when an agent is selected
- Don't send `model` parameter when `agent` is set, letting the agent's configured model take precedence

## Problem

When selecting an agent, the model selector remained visible, causing confusion since agents already have their model configured in OpenCode config.

## Changes

In `apps/web/src/routes/_app/session/$id.tsx`:
- Conditionally render `<ModelSelect />` only when no agent is selected
- Send `model: undefined` in the request when an agent is selected

Fixes #24