### PR TITLE
fix: Use configured hostname instead of hardcoded localhost

### DIFF
--- a/apps/web/src/server/lib/opencode-client.ts
+++ b/apps/web/src/server/lib/opencode-client.ts
@@ -1,25 +1,51 @@
 import { createOpencodeClient } from "@opencode-ai/sdk";
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
 
-// Cache clients per port to avoid recreating them
-const clientCache = new Map<number, ReturnType<typeof createOpencodeClient>>();
+const CONFIG_PATH = join(homedir(), ".portal.json");
+
+// Cache clients by host:port
+const clientCache = new Map<string, ReturnType<typeof createOpencodeClient>>();
+
+function getHostnameForPort(port: number): string {
+  try {
+    if (existsSync(CONFIG_PATH)) {
+      const config = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+      const instance = config.instances?.find(
+        (i: { opencodePort: number }) => i.opencodePort === port
+      );
+      if (instance?.hostname && instance.hostname !== "0.0.0.0") {
+        return instance.hostname;
+      }
+    }
+  } catch {
+    // Fall back to localhost
+  }
+  return "localhost";
+}
 
 export function getOpencodeClient(port: number) {
-  const cached = clientCache.get(port);
+  const hostname = getHostnameForPort(port);
+  const key = `${hostname}:${port}`;
+
+  const cached = clientCache.get(key);
   if (cached) {
     return cached;
   }
 
   const client = createOpencodeClient({
-    baseUrl: `http://localhost:${port}`,
+    baseUrl: `http://${hostname}:${port}`,
   });
 
-  clientCache.set(port, client);
+  clientCache.set(key, client);
   return client;
 }
 
 export function clearClientCache(port?: number) {
   if (port) {
-    clientCache.delete(port);
+    const hostname = getHostnameForPort(port);
+    clientCache.delete(`${hostname}:${port}`);
   } else {
     clientCache.clear();
   }


### PR DESCRIPTION
## Summary

Fixes Portal failing to connect to OpenCode when bound to a non-localhost interface (e.g., Tailscale IP for remote mobile access without exposing to local network, i.e. airports).

## Problem

The OpenCode client was hardcoded to connect to `localhost`:

```typescript
const client = createOpencodeClient({
  baseUrl: `http://localhost:${port}`,
});
```

When running `openportal --hostname 100.118.72.79` (a Tailscale IP), OpenCode binds to that interface but Portal's backend still tries to reach `localhost:4000`, resulting in 500 errors.

## Solution

Read the hostname from `~/.portal.json` (where Portal already stores instance config) and use it for the OpenCode client connection:

```typescript
function getHostnameForPort(port: number): string {
  const config = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
  const instance = config.instances?.find(i => i.opencodePort === port);
  if (instance?.hostname && instance.hostname !== "0.0.0.0") {
    return instance.hostname;
  }
  return "localhost";
}
```

This allows Portal to work correctly when OpenCode is bound to specific interfaces for remote access scenarios (Such as the Tailscale use cause outlined in the README).

## Testing

Tested with OpenCode bound to Tailscale IP, accessed from mobile device over Tailscale VPN.