### PR TITLE
Fix #28: Feature request: viewing mode

### DIFF
--- a/apps/web/src/routes/_app/session/$id.tsx
+++ b/apps/web/src/routes/_app/session/$id.tsx
@@ -679,6 +679,7 @@ function SessionPage() {
   const [sending, setSending] = useState(false);
   const [messageQueue, setMessageQueue] = useState<QueuedMessage[]>([]);
   const [modelOverride, setModelOverride] = useState(false);
+  const [viewingMode, setViewingMode] = useState(false);
   const [pendingPermissions, setPendingPermissions] = useState<
     PermissionRequest[]
   >([]);
@@ -967,7 +968,21 @@ function SessionPage() {
         )}
       </div>
 
-      <div className="border-t border-border p-4 shrink-0 relative">
+      <div className="border-t border-border shrink-0">
+        {viewingMode ? (
+          <div className="p-2 flex justify-end">
+            <button
+              type="button"
+              onClick={() => setViewingMode(false)}
+              className="rounded-md px-2.5 py-1.5 text-xs text-muted-fg hover:text-fg transition-colors flex items-center gap-1.5"
+              title="Exit view mode"
+            >
+              <IconEye size="14px" />
+              Exit view mode
+            </button>
+          </div>
+        ) : (
+        <div className="p-4 relative">
         <FileMentionPopover
           isOpen={fileMention.isOpen}
           searchQuery={fileMention.searchQuery}
@@ -1041,6 +1056,15 @@ function SessionPage() {
           <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center justify-between gap-2 sm:justify-start">
               <AgentSelect sessionId={sessionId} />
+              <button
+                type="button"
+                onClick={() => setViewingMode(true)}
+                className="rounded-md px-2 py-1 text-xs text-muted-fg hover:text-fg transition-colors flex items-center gap-1"
+                title="Switch to view mode"
+              >
+                <IconEye size="12px" />
+                View mode
+              </button>
             </div>
             <div className="flex items-center justify-between gap-2 sm:justify-end">
               {modelOverride ? (
@@ -1075,6 +1099,8 @@ function SessionPage() {
             </div>
           </div>
         </form>
+        </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #28

Adds a view mode toggle to `SessionPage` in `apps/web/src/routes/_app/session/$id.tsx` that hides the message input bar for a distraction-free reading experience.

## Changes

**`apps/web/src/routes/_app/session/$id.tsx` — `SessionPage` function**
- Added `viewingMode` boolean state (initialized to `false`) alongside existing state declarations near line 682.
- Refactored the bottom toolbar `div` (previously `border-t border-border p-4 shrink-0 relative`) into a conditional: when `viewingMode` is `true`, renders a minimal strip with only an "Exit view mode" button (`IconEye` + label, `text-xs`, right-aligned); when `false`, renders the full composer including `FileMentionPopover`, the input form, `AgentSelect`, and model controls inside a nested `div.p-4.relative`.
- Added a "View mode" button (`IconEye`, `text-xs`, `text-muted-fg`) inside the `AgentSelect` row that sets `viewingMode` to `true`.

## Motivation

Users reading through past sessions were forced to scroll with the full message input bar occupying bottom space. The view mode collapses that entire panel, leaving only a small exit affordance so users can return to composing without a page reload or navigation.

## Testing

1. Open any existing session with a message history.
2. Click the **View mode** button in the toolbar next to `AgentSelect` — confirm the composer, file mention popover, model selector, and send controls disappear.
3. Confirm the bottom bar shrinks to a single right-aligned **Exit view mode** button.
4. Click **Exit view mode** — confirm the full composer is restored and functional (typing, sending a message).
5. Verify no layout shift or overflow occurs in the message list when toggling between modes at various viewport widths.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*