### PR TITLE
feat(sessions): list and scope sessions per Portal instance

### DIFF
--- a/apps/web/src/server/lib/opencode-client.ts
+++ b/apps/web/src/server/lib/opencode-client.ts
@@ -60,6 +60,23 @@ export function getOpencodeClientV2(port: number) {
   return client;
 }
 
+export function getOpencodeBaseUrl(port: number): string {
+  return `http://${getHostnameForPort(port)}:${port}`;
+}
+
+export function getInstanceDirectory(port: number): string | undefined {
+  try {
+    if (existsSync(CONFIG_PATH)) {
+      const config = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+      const instance = config.instances?.find(
+        (i: { opencodePort: number }) => i.opencodePort === port,
+      );
+      return instance?.directory;
+    }
+  } catch {}
+  return undefined;
+}
+
 export function clearClientCache(port?: number) {
   if (port) {
     const hostname = getHostnameForPort(port);

--- a/apps/web/src/server/opencode/[port]/sessions.ts
+++ b/apps/web/src/server/opencode/[port]/sessions.ts
@@ -1,11 +1,64 @@
-import { defineHandler } from "nitro/h3";
-import { getOpencodeClient } from "../../lib/opencode-client";
+import { defineHandler, getQuery } from "nitro/h3";
+import { resolve } from "node:path";
+import {
+  getInstanceDirectory,
+  getOpencodeBaseUrl,
+  getOpencodeClient,
+} from "../../lib/opencode-client";
 import { parsePort } from "../../lib/validation";
 
+type Session = { directory?: string; [k: string]: unknown };
+
+// Returns true when `sessionDir` is `scope` itself or a descendant of `scope`.
+// Plain string prefix matching is wrong: it would let `/foo/bar-baz` match
+// scope `/foo/bar`. We compare normalized paths and require either equality
+// or a `/`-separated descent.
+function isUnder(sessionDir: string | undefined, scope: string): boolean {
+  if (!sessionDir) return false;
+  const s = resolve(scope);
+  const d = resolve(sessionDir);
+  return d === s || d.startsWith(s + "/");
+}
+
+// `client.session.list()` hits GET /session, which OpenCode filters to the
+// process's currently active project. /experimental/session returns sessions
+// across all projects, matching what OpenCode's own web UI shows. We fall
+// back to the SDK call so older OpenCode versions still work.
+//
+// Sessions are then filtered to those under the Portal instance's
+// `--directory`, so each instance shows the sub-tree it was started for.
+// Override with `?scope=all` (full list) or `?directory=<path>` (custom).
 export default defineHandler(async (event) => {
   const port = parsePort(event);
-  const client = getOpencodeClient(port);
-  const sessions = await client.session.list();
+  const query = getQuery(event);
 
-  return sessions.data;
+  let sessions: Session[];
+  try {
+    const res = await fetch(`${getOpencodeBaseUrl(port)}/experimental/session`);
+    if (!res.ok) throw new Error(`upstream ${res.status}`);
+    sessions = (await res.json()) as Session[];
+  } catch {
+    sessions = ((await getOpencodeClient(port).session.list()).data ?? []) as Session[];
+  }
+
+  const scope = pickScope(query, port);
+  if (!scope) return sessions;
+
+  return sessions.filter((s) => isUnder(s.directory, scope));
 });
+
+function pickScope(
+  query: Record<string, unknown>,
+  port: number,
+): string | undefined {
+  const explicitScope = typeof query.scope === "string" ? query.scope : undefined;
+  if (explicitScope === "all") return undefined;
+
+  const explicitDir =
+    typeof query.directory === "string" ? query.directory : undefined;
+  if (explicitDir) return explicitDir;
+
+  const instanceDir = getInstanceDirectory(port);
+  if (!instanceDir || instanceDir === "/") return undefined;
+  return instanceDir;
+}


### PR DESCRIPTION
## Problem

OpenCode's stable `GET /session` endpoint filters its results to the OpenCode process's currently active project. As a consequence, Portal's session list shows sessions from only one project at a time, even though the underlying OpenCode database holds sessions for many.

The flat-but-single-project list is confusing for users who maintain many projects: when you point Portal at a directory, you see your global sessions plus that directory's sessions, but every other project's sessions are silently hidden.

After fixing the visibility, the *opposite* problem also matters: a Portal instance that was started against a sub-tree (e.g. `--directory ~/projects/work`) should not have to scroll through sessions from unrelated trees. Each instance should focus on the sub-tree it was started for.

## What this PR does

Two changes, one commit each.

### 1. List all sessions across all projects (commit 1)

OpenCode's first-party web UI uses `GET /experimental/session`, which returns sessions across every project the OpenCode server knows about. Switch Portal's `/api/opencode/[port]/sessions` route to the same endpoint so Portal's session list mirrors what OpenCode itself shows.

A small `getOpencodeBaseUrl(port)` helper is added to `opencode-client.ts` so handlers that need a raw URL (rather than the SDK client) don't have to reimplement hostname resolution from `~/.portal.json`.

The new code falls back to the SDK call (`client.session.list()`) when `/experimental/session` is not OK (older OpenCode versions, future renames), so users on stale OpenCode binaries continue to see something rather than an empty list.

### 2. Scope to the instance's `--directory` by default (commit 2)

After (1) the session list is global. To keep multi-instance setups useful, results are filtered to sessions whose `directory` is at or under the Portal instance's `--directory`.

Two query overrides are honored on `/api/opencode/[port]/sessions`:

- `?scope=all` — return everything (the unfiltered behavior from commit 1).
- `?directory=<path>` — scope to an arbitrary path. Useful for drilling into a specific project from a Portal instance whose `--directory` is broader.

Path matching is path-component-aware: `/foo/bar` matches `/foo/bar` and `/foo/bar/...` but NOT `/foo/bar-baz`. Implemented with `path.resolve` plus an explicit `/` boundary check.

Instances whose `--directory` is `/` are treated as unscoped (no filter applied).

A `getInstanceDirectory(port)` helper is added next to `getOpencodeBaseUrl`.

## Compatibility

- The `/experimental/*` namespace is officially marked experimental upstream. In practice it is reasonably stable since OpenCode's own UI depends on it.
- Behavior change for existing Portal users: a Portal instance with `--directory ~/projects/foo` no longer shows sessions from other projects unless `?scope=all` is passed. This is intentional and matches user expectation.
- The SDK fallback ensures stale OpenCode binaries keep working.

## Test plan

1. Run two Portal instances, one at `--directory ~/projects` and one at `--directory ~/projects/foo`, against the same OpenCode server.
2. Default behavior: instance at `~/projects` shows all sessions under `~/projects/...`; instance at `~/projects/foo` shows only that sub-tree.
3. `?scope=all` on either: full firehose.
4. `?directory=/some/path`: results constrained to that path. Override works even when the path is outside the instance's `--directory`.
5. Sibling exclusion: a session in `~/projects/foo-bar` is NOT shown by an instance whose scope is `~/projects/foo`.

All five verified manually with two Portal instances against a server holding 95 sessions across 16 projects: 89 (parent scope), 34 (sub-tree), 95 (`?scope=all`), 13 (`?directory=` exact), 0 (sibling).

## Notes

- No test files exist under `apps/web/src/server/` today; happy to add coverage if there is a preferred harness.
- `bun.lock` changes from `bun install` were deliberately not committed; this PR touches application code only.
