### PR TITLE
Improve session UI: fork/revert, stop control, subagent view, and rendered question answers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 .DS_Store
 *.pem
 .idea/
+gdb/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "react-aria-components": "^1.17.0",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "swr": "^2.4.1",

--- a/apps/web/src/components/app-sidebar-nav.tsx
+++ b/apps/web/src/components/app-sidebar-nav.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useMatch } from "@tanstack/react-router";
 import { Breadcrumbs, BreadcrumbsItem } from "@/components/ui/breadcrumbs";
 import { Button } from "@/components/ui/button";
@@ -7,14 +7,17 @@ import { toast } from "@/components/ui/toast";
 import {
   ArrowDownCircleIcon,
   ArrowUpCircleIcon,
+  IconGitBranch,
   IconGitPullRequest,
 } from "@/components/icons/lucide";
 import { useInstanceStore } from "@/stores/instance-store";
 import { useModelStore } from "@/stores/model-store";
 import { useBreadcrumb } from "@/contexts/breadcrumb-context";
-import { mutateSessionMessages } from "@/hooks/use-session-messages";
+import { useSessionMessages, mutateSessionMessages } from "@/hooks/use-session-messages";
 import { useSessions } from "@/hooks/use-opencode";
 import { backendBasePath } from "@/lib/backend-url";
+import { formatCost } from "@/lib/format";
+import type { SessionMessageAssistant } from "@opencode-ai/sdk/v2";
 
 const CREATE_PR_PROMPT = `Use gh CLI to create a pull request. Follow these steps:
 
@@ -74,12 +77,25 @@ export function AppSidebarNav() {
   const [isCreatingPR, setIsCreatingPR] = useState(false);
   const [isPulling, setIsPulling] = useState(false);
   const [isPushing, setIsPushing] = useState(false);
+  const [showGitButtons, setShowGitButtons] = useState(false);
 
   const sessionMatch = useMatch({
     from: "/_app/session/$id",
     shouldThrow: false,
   });
   const sessionId = sessionMatch?.params?.id;
+
+  const { sessionMessages } = useSessionMessages(sessionId);
+
+  const sessionStats = useMemo(() => {
+    let totalCost = 0;
+    for (const msg of sessionMessages) {
+      if (msg.type !== "assistant") continue;
+      const am = msg as SessionMessageAssistant;
+      totalCost += am.cost ?? 0;
+    }
+    return { cost: totalCost };
+  }, [sessionMessages]);
 
   const sendPrompt = async (prompt: string) => {
     if (!sessionId || !port) {
@@ -160,35 +176,53 @@ export function AppSidebarNav() {
         </Breadcrumbs>
       </span>
       <span className="flex items-center gap-x-2 ml-auto">
+        {showGitButtons ? (
+          <>
+            <Button
+              size="xs"
+              intent="outline"
+              className="uppercase font-mono"
+              onPress={handlePull}
+              isDisabled={isLoading || !sessionId}
+            >
+              <ArrowDownCircleIcon size="14px" />
+              {isPulling ? "Pulling..." : "Pull"}
+            </Button>
+            <Button
+              size="xs"
+              intent="outline"
+              className="uppercase font-mono"
+              onPress={handlePush}
+              isDisabled={isLoading || !sessionId}
+            >
+              <ArrowUpCircleIcon size="14px" />
+              {isPushing ? "Pushing..." : "Push"}
+            </Button>
+            <Button
+              size="xs"
+              intent="outline"
+              className="uppercase font-mono"
+              onPress={handleCreatePR}
+              isDisabled={isLoading || !sessionId}
+            >
+              <IconGitPullRequest size="14px" />
+              {isCreatingPR ? "Creating..." : "PR"}
+            </Button>
+          </>
+        ) : (
+          <span className="flex items-center gap-2 text-xs text-muted-fg font-mono">
+            {sessionStats.cost > 0 && (
+              <span>{formatCost(sessionStats.cost)}</span>
+            )}
+          </span>
+        )}
         <Button
           size="xs"
           intent="outline"
           className="uppercase font-mono"
-          onPress={handlePull}
-          isDisabled={isLoading || !sessionId}
+          onPress={() => setShowGitButtons((v) => !v)}
         >
-          <ArrowDownCircleIcon size="14px" />
-          {isPulling ? "Pulling..." : "Pull"}
-        </Button>
-        <Button
-          size="xs"
-          intent="outline"
-          className="uppercase font-mono"
-          onPress={handlePush}
-          isDisabled={isLoading || !sessionId}
-        >
-          <ArrowUpCircleIcon size="14px" />
-          {isPushing ? "Pushing..." : "Push"}
-        </Button>
-        <Button
-          size="xs"
-          intent="outline"
-          className="uppercase font-mono"
-          onPress={handleCreatePR}
-          isDisabled={isLoading || !sessionId}
-        >
-          <IconGitPullRequest size="14px" />
-          {isCreatingPR ? "Creating..." : "Create PR"}
+          <IconGitBranch size="14px" />
         </Button>
       </span>
     </SidebarNav>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -55,7 +55,7 @@ import {
   useInstances,
 } from "@/hooks/use-opencode";
 import { useInstanceStore } from "@/stores/instance-store";
-import { useNavigate, useMatch } from "@tanstack/react-router";
+import { useNavigate, useMatch, useParams } from "@tanstack/react-router";
 import type { Session } from "@opencode-ai/sdk/v2";
 import type { BackendProvider } from "@/lib/backend-url";
 
@@ -191,6 +191,9 @@ export default function AppSidebar(
   const { data: hostnameData } = useHostname();
   const hostname = hostnameData?.hostname ?? "Loading...";
   const { data: sessionsData, mutate: mutateSessions } = useSessions();
+  const { id: activeSessionId } = useParams({ strict: false }) as {
+    id?: string;
+  };
   const createSession = useCreateSession();
   const deleteSession = useDeleteSession();
   const sessions: Session[] = sessionsData ?? [];
@@ -283,7 +286,16 @@ export default function AppSidebar(
 
           <SidebarSection label="Sessions">
             {sessions.map((session) => (
-              <SidebarItem key={session.id} tooltip={session.title}>
+              <SidebarItem
+                key={session.id}
+                tooltip={session.title}
+                isCurrent={session.id === activeSessionId}
+                className={
+                  session.id === activeSessionId
+                    ? "bg-sidebar-accent text-sidebar-accent-fg"
+                    : undefined
+                }
+              >
                 {({ isCollapsed, isFocused }) => (
                   <>
                     <SidebarLink href={`/session/${session.id}`}>

--- a/apps/web/src/components/icons/lucide.tsx
+++ b/apps/web/src/components/icons/lucide.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon, LucideProps } from "lucide-react";
 import {
+  ArrowLeft,
   Check,
   ChevronDown,
   ChevronRight,
@@ -13,6 +14,7 @@ import {
   FileDiff,
   FileText,
   Folder,
+  GitBranch,
   GitPullRequest,
   Globe,
   GripVertical,
@@ -21,6 +23,7 @@ import {
   Info,
   KeyRound,
   LifeBuoy,
+  ListChecks,
   LogOut,
   MessageCircle,
   MessageSquare,
@@ -40,6 +43,7 @@ import {
   Settings,
   ShieldCheck,
   Sparkles,
+  Square,
   Sun,
   Trash2,
   User,
@@ -65,6 +69,7 @@ export function createAppIcon(
   };
 }
 
+export const ArrowLeftIcon = createAppIcon(ArrowLeft);
 export const ArrowDownCircleIcon = createAppIcon(CircleArrowDown);
 export const ArrowPathIcon = createAppIcon(RefreshCw);
 export const ArrowRightStartOnRectangleIcon = createAppIcon(LogOut);
@@ -102,6 +107,7 @@ export const IconBadgeSparkle = createAppIcon(Sparkles);
 export const IconBox = createAppIcon(Box, "18px");
 export const IconChat = createAppIcon(MessageCircle, "18px");
 export const IconEye = createAppIcon(Eye);
+export const IconGitBranch = createAppIcon(GitBranch, "18px");
 export const IconGitPullRequest = createAppIcon(GitPullRequest, "18px");
 export const IconGridPlus = createAppIcon(Grid2X2Plus, "18px");
 export const IconMagnifier = createAppIcon(Search);
@@ -112,4 +118,6 @@ export const IconThemeDark = createAppIcon(Moon, "18px");
 export const IconThemeLight = createAppIcon(Sun, "18px");
 export const IconThemeSystem = createAppIcon(Monitor, "18px");
 export const IconUser = createAppIcon(User);
+export const IconListChecks = createAppIcon(ListChecks);
 export const SendIcon = createAppIcon(Send);
+export const StopIcon = createAppIcon(Square);

--- a/apps/web/src/components/icons/lucide.tsx
+++ b/apps/web/src/components/icons/lucide.tsx
@@ -9,6 +9,7 @@ import {
   CircleArrowUp,
   Cpu,
   Ellipsis,
+  EllipsisVertical,
   Eye,
   Feather,
   FileDiff,
@@ -46,6 +47,7 @@ import {
   Square,
   Sun,
   Trash2,
+  Undo2,
   User,
   X,
 } from "lucide-react";
@@ -121,3 +123,5 @@ export const IconUser = createAppIcon(User);
 export const IconListChecks = createAppIcon(ListChecks);
 export const SendIcon = createAppIcon(Send);
 export const StopIcon = createAppIcon(Square);
+export const UndoIcon = createAppIcon(Undo2);
+export const IconEllipsisVertical = createAppIcon(EllipsisVertical);

--- a/apps/web/src/hooks/use-opencode.ts
+++ b/apps/web/src/hooks/use-opencode.ts
@@ -249,3 +249,43 @@ export function useAbortSession() {
     return res.json();
   };
 }
+
+export function useForkSession() {
+  const backend = useBackend();
+
+  return async (sessionId: string, messageID?: string) => {
+    if (!backend) throw new Error("No instance selected");
+
+    const res = await fetch(`${backend.basePath}/session/${sessionId}/fork`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messageID }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to fork session: ${res.status}`);
+    }
+
+    return res.json();
+  };
+}
+
+export function useRevertSession() {
+  const backend = useBackend();
+
+  return async (sessionId: string, messageID: string) => {
+    if (!backend) throw new Error("No instance selected");
+
+    const res = await fetch(`${backend.basePath}/session/${sessionId}/revert`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messageID }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to revert session: ${res.status}`);
+    }
+
+    return res.json();
+  };
+}

--- a/apps/web/src/hooks/use-resolve-session-instance.ts
+++ b/apps/web/src/hooks/use-resolve-session-instance.ts
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from "react";
+import { useInstances } from "@/hooks/use-opencode";
+import { useInstanceStore, type Instance } from "@/stores/instance-store";
+import { backendBasePath, type BackendProvider } from "@/lib/backend-url";
+
+export type ResolveStatus = "idle" | "resolving" | "found" | "notFound";
+
+interface InstanceData {
+  id: string;
+  name: string;
+  port: number;
+  provider?: BackendProvider;
+}
+
+function toInstance(item: InstanceData): Instance {
+  return {
+    id: item.id,
+    name: item.name,
+    port: item.port,
+    provider: item.provider ?? "opencode",
+  };
+}
+
+function sameInstance(a: Instance | null, b: Instance | null): boolean {
+  if (!a || !b) return false;
+  return (
+    a.id === b.id &&
+    a.port === b.port &&
+    (a.provider ?? "opencode") === (b.provider ?? "opencode")
+  );
+}
+
+async function instanceOwnsSession(
+  instance: Instance,
+  sessionId: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `${backendBasePath(instance.provider, instance.port)}/sessions`,
+    );
+    if (!res.ok) return false;
+    const list = await res.json();
+    return (
+      Array.isArray(list) &&
+      list.some((session) => session?.id === sessionId)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find which running instance owns the given session id. Checks the currently
+ * selected instance first (fast path), then scans the rest in parallel.
+ */
+export async function findInstanceForSession(
+  instances: Instance[],
+  sessionId: string,
+  selected: Instance | null,
+): Promise<Instance | null> {
+  if (selected && (await instanceOwnsSession(selected, sessionId))) {
+    return selected;
+  }
+
+  const others = instances.filter((item) => !sameInstance(item, selected));
+  const matches = await Promise.all(
+    others.map(async (item) =>
+      (await instanceOwnsSession(item, sessionId)) ? item : null,
+    ),
+  );
+
+  return matches.find((item): item is Instance => item !== null) ?? null;
+}
+
+/**
+ * Resolves the instance that owns a deep-linked session id and selects it.
+ *
+ * - When an instance is already selected, the UI is not blocked (status stays
+ *   "found"); resolution still runs in the background to correct cross-instance
+ *   links.
+ * - When no instance is selected yet (fresh load / shared link), status is
+ *   "resolving" until the owning instance is located.
+ */
+export function useResolveSessionInstance(
+  sessionId: string | undefined,
+): ResolveStatus {
+  const { data } = useInstances();
+  const instance = useInstanceStore((s) => s.instance);
+  const setInstance = useInstanceStore((s) => s.setInstance);
+  const [status, setStatus] = useState<ResolveStatus>("idle");
+  const resolvedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) {
+      resolvedFor.current = null;
+      setStatus("idle");
+      return;
+    }
+
+    if (resolvedFor.current === sessionId) return;
+
+    if (!data) {
+      if (!instance) setStatus("resolving");
+      return;
+    }
+
+    const instances: Instance[] = (
+      (data.instances ?? []) as InstanceData[]
+    ).map(toInstance);
+
+    let cancelled = false;
+
+    setStatus(instance ? "found" : "resolving");
+
+    void (async () => {
+      const match = await findInstanceForSession(
+        instances,
+        sessionId,
+        instance,
+      );
+      if (cancelled) return;
+
+      if (match) {
+        if (!sameInstance(instance, match)) setInstance(match);
+        resolvedFor.current = sessionId;
+        setStatus("found");
+      } else {
+        resolvedFor.current = sessionId;
+        setStatus("notFound");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, data, instance, setInstance]);
+
+  return status;
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,0 +1,11 @@
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+export function formatCost(n: number): string {
+  if (n === 0) return "$0";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}

--- a/apps/web/src/main.css
+++ b/apps/web/src/main.css
@@ -375,3 +375,8 @@ body {
 .dark .diff-code-delete {
   background-color: oklch(0.577 0.245 27.325 / 0.1);
 }
+
+.prose :where(code):not(:where(pre code)) {
+  overflow-wrap: break-word;
+  word-break: break-all;
+}

--- a/apps/web/src/routes/_app.tsx
+++ b/apps/web/src/routes/_app.tsx
@@ -1,10 +1,19 @@
-import { createFileRoute, Outlet, Navigate } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Outlet,
+  Navigate,
+  Link,
+  useParams,
+} from "@tanstack/react-router";
 import { useEffect } from "react";
 import AppSidebar from "@/components/app-sidebar";
 import { AppSidebarNav } from "@/components/app-sidebar-nav";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { BreadcrumbProvider } from "@/contexts/breadcrumb-context";
+import { buttonStyles } from "@/components/ui/button";
+import { Loader } from "@/components/ui/loader";
 import { useInstances } from "@/hooks/use-opencode";
+import { useResolveSessionInstance } from "@/hooks/use-resolve-session-instance";
 import { useInstanceStore } from "@/stores/instance-store";
 import { useOpencodeEvents } from "@/hooks/use-opencode-events";
 import type { BackendProvider } from "@/lib/backend-url";
@@ -13,11 +22,36 @@ export const Route = createFileRoute("/_app")({
   component: AppLayout,
 });
 
+function FullScreenLoader() {
+  return (
+    <div className="flex h-dvh items-center justify-center">
+      <Loader aria-label="Loading session" className="size-6" />
+    </div>
+  );
+}
+
+function SessionNotFound({ id }: { id: string }) {
+  return (
+    <div className="flex h-dvh flex-col items-center justify-center gap-3 p-6 text-center">
+      <h1 className="text-lg font-semibold">Session not found</h1>
+      <p className="text-muted-fg text-sm">
+        No running instance owns the session{" "}
+        <code className="font-mono">{id}</code>.
+      </p>
+      <Link to="/instances" className={buttonStyles()}>
+        Choose an instance
+      </Link>
+    </div>
+  );
+}
+
 function AppLayout() {
   const instance = useInstanceStore((s) => s.instance);
   const setInstance = useInstanceStore((s) => s.setInstance);
   const clearInstance = useInstanceStore((s) => s.clearInstance);
   const { data } = useInstances();
+  const { id: sessionId } = useParams({ strict: false }) as { id?: string };
+  const resolveStatus = useResolveSessionInstance(sessionId);
   const instances: Array<{
     id: string;
     name: string;
@@ -27,6 +61,11 @@ function AppLayout() {
 
   useEffect(() => {
     if (!data) return;
+
+    // Deep-linked session routes resolve their own instance via
+    // useResolveSessionInstance; skip the generic auto-select here so we don't
+    // pick the wrong instance in a multi-instance setup.
+    if (sessionId) return;
 
     if (instances.length === 0) {
       if (instance) clearInstance();
@@ -52,11 +91,16 @@ function AppLayout() {
       port: next.port,
       provider: next.provider ?? "opencode",
     });
-  }, [clearInstance, data, instance, instances, setInstance]);
+  }, [clearInstance, data, instance, instances, sessionId, setInstance]);
 
   useOpencodeEvents(instance?.port, instance?.provider);
 
-  if (!instance) {
+  if (sessionId) {
+    if (resolveStatus === "notFound") return <SessionNotFound id={sessionId} />;
+    if (!instance || resolveStatus === "resolving") {
+      return <FullScreenLoader />;
+    }
+  } else if (!instance) {
     if (data && instances.length > 0) return null;
     return <Navigate to="/instances" />;
   }

--- a/apps/web/src/routes/_app/session/$id.tsx
+++ b/apps/web/src/routes/_app/session/$id.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState, useCallback, useMemo, memo } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -30,8 +30,25 @@ import {
   InformationCircleIcon,
   SendIcon,
   StopIcon,
+  UndoIcon,
+  IconEllipsisVertical,
+  IconGitBranch,
 } from "@/components/icons/lucide";
+import {
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuTrigger,
+} from "@/components/ui/menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTitle,
+  PopoverDescription,
+  PopoverClose,
+} from "@/components/ui/popover";
 import { useAgentStore } from "@/stores/agent-store";
+import { useDraftStore } from "@/stores/draft-store";
 import { useInstanceStore } from "@/stores/instance-store";
 import { useModelStore } from "@/stores/model-store";
 import { useBreadcrumb } from "@/contexts/breadcrumb-context";
@@ -52,6 +69,8 @@ import {
 } from "@/hooks/use-session-messages";
 import {
   useAbortSession,
+  useForkSession,
+  useRevertSession,
   useAgents,
   usePermissions,
   useQuestions,
@@ -1103,6 +1122,9 @@ const MessageItem = memo(function MessageItem({
   pendingQuestions,
   onPermissionResolved,
   onQuestionResolved,
+  showActions,
+  onFork,
+  onRevert,
 }: {
   message: MessageWithParts;
   port: number;
@@ -1112,6 +1134,9 @@ const MessageItem = memo(function MessageItem({
   pendingQuestions: QuestionRequest[];
   onPermissionResolved: (requestId: string) => void;
   onQuestionResolved: (requestId: string) => void;
+  showActions?: boolean;
+  onFork?: (messageId: string, text: string) => void;
+  onRevert?: (messageId: string) => void;
 }) {
   const textContent = getMessageContent(message.parts);
   const isAssistant = message.info.role === "assistant";
@@ -1154,6 +1179,30 @@ const MessageItem = memo(function MessageItem({
               />
             )}
           </div>
+          {!isAssistant && showActions && (
+            <Menu>
+              <MenuTrigger
+                aria-label="Message actions"
+                className="shrink-0 mt-1 p-0.5 rounded text-muted-fg hover:text-fg hover:bg-muted/60 transition-colors"
+              >
+                <IconEllipsisVertical size="14px" />
+              </MenuTrigger>
+              <MenuContent placement="bottom end">
+                <MenuItem
+                  onAction={() => onFork?.(message.info.id, textContent || "")}
+                >
+                  <IconGitBranch size="14px" className="mr-2" />
+                  Fork
+                </MenuItem>
+                <MenuItem
+                  onAction={() => onRevert?.(message.info.id)}
+                >
+                  <UndoIcon size="14px" className="mr-2" />
+                  Revert
+                </MenuItem>
+              </MenuContent>
+            </Menu>
+          )}
         </div>
       )}
       {toolCalls.length > 0 && (
@@ -1269,11 +1318,22 @@ function SessionPage() {
     supportsAgentSelection,
   ]);
 
+  const consumeDraft = useDraftStore((s) => s.consumeDraft);
+
   const [sendError, setSendError] = useState<string | null>(null);
+  const [confirmStopOpen, setConfirmStopOpen] = useState(false);
   const [input, setInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasScrolledInitially, setHasScrolledInitially] = useState(false);
   const [fileResults, setFileResults] = useState<string[]>([]);
+
+  useEffect(() => {
+    const draft = consumeDraft(sessionId);
+    if (draft) {
+      setInput(draft);
+    }
+  }, [sessionId, consumeDraft]);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -1317,6 +1377,47 @@ function SessionPage() {
       );
     }
   }, [sessionId, abortSession, port, provider, mutateSessionStatuses]);
+
+  const navigate = useNavigate();
+  const forkSession = useForkSession();
+  const revertSession = useRevertSession();
+  const setDraft = useDraftStore((s) => s.setDraft);
+
+  const handleFork = useCallback(
+    async (messageId: string, text: string) => {
+      if (!sessionId) return;
+      try {
+        const newSession = await forkSession(sessionId, messageId);
+        if (text) {
+          setDraft(newSession.id, text);
+        }
+        mutateSessions();
+        navigate({ to: "/session/$id", params: { id: newSession.id } });
+      } catch (error) {
+        setSendError(
+          error instanceof Error ? error.message : "Failed to fork session",
+        );
+      }
+    },
+    [sessionId, forkSession, setDraft, mutateSessions, navigate],
+  );
+
+  const handleRevert = useCallback(
+    async (messageId: string) => {
+      if (!sessionId) return;
+      try {
+        await revertSession(sessionId, messageId);
+        mutateSessionMessages(port, sessionId, provider);
+        mutateSessions();
+        mutateSessionStatuses();
+      } catch (error) {
+        setSendError(
+          error instanceof Error ? error.message : "Failed to revert session",
+        );
+      }
+    },
+    [sessionId, revertSession, port, provider, mutateSessions, mutateSessionStatuses],
+  );
 
   const pendingPermissions = useMemo(
     () =>
@@ -1607,6 +1708,9 @@ function SessionPage() {
                 pendingQuestions={pendingQuestions}
                 onPermissionResolved={handlePermissionResolved}
                 onQuestionResolved={handleQuestionResolved}
+                showActions={provider === "opencode"}
+                onFork={handleFork}
+                onRevert={handleRevert}
               />
             ))}
           {unlinkedPermissions.length > 0 && (
@@ -1754,18 +1858,58 @@ function SessionPage() {
               rows={5}
             />
             {sending ? (
-              <Button
-                type="button"
-                onPress={handleAbort}
-                isCircle
-                size="sq-sm"
-                aria-label="Stop run"
-                className="absolute right-3 bottom-3"
-              >
-                <span className="grid size-4 place-items-center">
-                  <StopIcon size="14px" className="fill-current" />
-                </span>
-              </Button>
+              <Popover isOpen={confirmStopOpen} onOpenChange={setConfirmStopOpen}>
+                <Button
+                  type="button"
+                  isCircle
+                  size="sq-sm"
+                  aria-label="Stop run"
+                  className="absolute right-3 bottom-3"
+                >
+                  <span className="grid size-4 place-items-center">
+                    <StopIcon size="14px" className="fill-current" />
+                  </span>
+                </Button>
+                <PopoverContent
+                  placement="top end"
+                  className="w-72 max-w-[calc(100vw-2rem)] rounded-2xl p-0"
+                >
+                  <div className="flex flex-col gap-4 p-4">
+                    <div className="flex items-start gap-3">
+                      <span className="grid size-9 shrink-0 place-items-center rounded-full bg-danger/12 text-danger">
+                        <StopIcon size="16px" className="fill-current" />
+                      </span>
+                      <div className="space-y-1 pt-0.5">
+                        <PopoverTitle className="font-semibold text-fg text-sm/5">
+                          Stop this run?
+                        </PopoverTitle>
+                        <PopoverDescription className="text-muted-fg text-xs/5">
+                          This cancels the current run. Any in-progress work will
+                          be aborted.
+                        </PopoverDescription>
+                      </div>
+                    </div>
+                    <div className="flex justify-end gap-2">
+                      <PopoverClose
+                        size="sm"
+                        className="border-transparent bg-transparent text-muted-fg [background:transparent] [box-shadow:none] [--btn-shadow-ring:transparent] hover:text-fg hover:[background:color-mix(in_oklab,var(--color-fg)_8%,transparent)] pressed:[background:color-mix(in_oklab,var(--color-fg)_12%,transparent)]"
+                      >
+                        Keep running
+                      </PopoverClose>
+                      <Button
+                        size="sm"
+                        onPress={() => {
+                          setConfirmStopOpen(false);
+                          void handleAbort();
+                        }}
+                        className="border-transparent text-danger-fg [background:var(--color-danger)] [box-shadow:none] [--btn-shadow-ring:transparent] hover:[background:color-mix(in_oklab,var(--color-danger)_90%,black_10%)] pressed:[background:color-mix(in_oklab,var(--color-danger)_82%,black_18%)]"
+                      >
+                        Stop run
+                      </Button>
+                    </div>
+                  </div>
+                </PopoverContent>
+              </Popover>
             ) : (
               <Button
                 type="submit"

--- a/apps/web/src/routes/_app/session/$id.tsx
+++ b/apps/web/src/routes/_app/session/$id.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { useEffect, useRef, useState, useCallback, useMemo, memo } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import { Ripples } from "ldrs/react";
 import "ldrs/react/Ripples.css";
 import { Button } from "@/components/ui/button";
@@ -15,14 +16,20 @@ import {
   useFileMention,
 } from "@/components/file-mention-popover";
 import {
+  ArrowLeftIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
   IconBadgeSparkle,
   IconEye,
+  IconListChecks,
   IconMagnifier,
   IconPen,
   IconSquareFeather,
   IconUser,
   InformationCircleIcon,
   SendIcon,
+  StopIcon,
 } from "@/components/icons/lucide";
 import { useAgentStore } from "@/stores/agent-store";
 import { useInstanceStore } from "@/stores/instance-store";
@@ -44,6 +51,7 @@ import {
   type QuestionRequest,
 } from "@/hooks/use-session-messages";
 import {
+  useAbortSession,
   useAgents,
   usePermissions,
   useQuestions,
@@ -55,8 +63,14 @@ import {
   isValidUserSelectableAgent,
 } from "@/lib/agent-selection";
 import { getErrorMessage, getResponseErrorMessage } from "@/lib/error-message";
+import { formatTokens, formatCost } from "@/lib/format";
 import { backendBasePath, type BackendProvider } from "@/lib/backend-url";
-import type { Agent, Session, SessionMessage } from "@opencode-ai/sdk/v2";
+import type {
+  Agent,
+  Session,
+  SessionMessage,
+  SessionMessageAssistant,
+} from "@opencode-ai/sdk/v2";
 
 export const Route = createFileRoute("/_app/session/$id")({
   component: SessionPage,
@@ -78,6 +92,12 @@ function isValidSessionAgent(agents: Agent[], name?: string) {
 
 function getDefaultSessionAgentName(agents: Agent[]) {
   return getDefaultUserSelectableAgentName(agents);
+}
+
+// formatTokens and formatCost imported from @/lib/format
+
+function stripModelDateSuffix(modelId: string): string {
+  return modelId.replace(/-\d{8}$/, "");
 }
 
 const OPENCODE_ID_LENGTH = 26;
@@ -241,14 +261,74 @@ function formatToolCall(part: ToolPart): {
         details: path ? `in ${path}` : undefined,
       };
     }
+    case "todowrite": {
+      const todos = Array.isArray(input.todos) ? input.todos : [];
+      const completed = todos.filter(
+        (t: Record<string, unknown>) => t.status === "completed",
+      ).length;
+      const inProgress = todos.filter(
+        (t: Record<string, unknown>) => t.status === "in_progress",
+      ).length;
+      const pending = todos.filter(
+        (t: Record<string, unknown>) => t.status === "pending",
+      ).length;
+      const parts: string[] = [];
+      if (completed) parts.push(`${completed} done`);
+      if (inProgress) parts.push(`${inProgress} active`);
+      if (pending) parts.push(`${pending} pending`);
+      return {
+        icon: <IconListChecks size="12px" />,
+        label: `todos (${todos.length})`,
+        details: parts.length ? parts.join(", ") : undefined,
+      };
+    }
+    case "task":
+    case "mcp_task": {
+      const agent = String(input.subagent_type || "agent");
+      const desc = String(input.description || "");
+      return {
+        icon: <IconBadgeSparkle size="12px" />,
+        label: agent,
+        details: desc || undefined,
+      };
+    }
+    case "question":
+    case "mcp_question": {
+      const questions = Array.isArray(input.questions)
+        ? input.questions
+        : [];
+      const count = questions.length;
+      const firstHeader =
+        count > 0 && typeof questions[0] === "object" && questions[0] !== null
+          ? String(
+              (questions[0] as Record<string, unknown>).header ||
+                (questions[0] as Record<string, unknown>).question ||
+                "",
+            )
+          : "";
+      return {
+        icon: "?",
+        label: `question${count > 1 ? ` (${count})` : ""}`,
+        details: firstHeader
+          ? firstHeader.slice(0, 40) + (firstHeader.length > 40 ? "..." : "")
+          : undefined,
+      };
+    }
     default: {
       const firstArg = Object.entries(input)[0];
+      let detailStr: string | undefined;
+      if (firstArg) {
+        const val = firstArg[1];
+        const valStr =
+          typeof val === "object" && val !== null
+            ? JSON.stringify(val)
+            : String(val);
+        detailStr = `${firstArg[0]}: ${valStr.slice(0, 30)}${valStr.length > 30 ? "..." : ""}`;
+      }
       return {
         icon: "◼︎",
         label: toolName || "unknown",
-        details: firstArg
-          ? `${firstArg[0]}: ${String(firstArg[1]).slice(0, 30)}...`
-          : undefined,
+        details: detailStr,
       };
     }
   }
@@ -303,14 +383,118 @@ function QuestionDisplay({
   );
 }
 
+/**
+ * Strip XML-like tool output tags that leak into assistant text content.
+ * These come from compaction/synthetic messages that inline tool results.
+ */
+function sanitizeMessageText(text: string): string {
+  let cleaned = text;
+
+  // Strip tool output XML blocks: <path>...<type>...<content>...</content>
+  cleaned = cleaned.replace(
+    /<path>[\s\S]*?<\/path>\s*(?:<type>[\s\S]*?<\/type>\s*)?(?:<content>[\s\S]*?<\/content>)?/g,
+    "",
+  );
+
+  // Strip standalone <content>...</content> or <type>...</type> blocks
+  cleaned = cleaned.replace(/<content>[\s\S]*?<\/content>/g, "");
+  cleaned = cleaned.replace(/<type>[^<]*<\/type>/g, "");
+
+  // Strip system metadata tags
+  cleaned = cleaned.replace(
+    /<dcp-message-id>[\s\S]*?<\/dcp-message-id>/g,
+    "",
+  );
+  cleaned = cleaned.replace(
+    /<dcp-system-reminder>[\s\S]*?<\/dcp-system-reminder>/g,
+    "",
+  );
+  cleaned = cleaned.replace(
+    /<system-reminder>[\s\S]*?<\/system-reminder>/g,
+    "",
+  );
+  cleaned = cleaned.replace(
+    /<antml_thinking>[\s\S]*?<\/antml_thinking>/g,
+    "",
+  );
+
+  // Strip "Called the X tool with the following input: {JSON}" lines
+  // These are rendered separately as synthetic ToolCallItems
+  cleaned = cleaned.replace(
+    /(?:I\s+)?[Cc]alled\s+the\s+(\w+)\s+tool\s+with\s+the\s+following\s+input:\s*\{[\s\S]*?\}/g,
+    "",
+  );
+
+  // Collapse excessive blank lines left after stripping
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n");
+
+  return cleaned.trim();
+}
+
 function getMessageContent(parts: Part[]): string {
-  return parts
+  const raw = parts
     .filter(
       (part): part is Part & { type: "text"; text: string } =>
         part.type === "text" && "text" in part && !!part.text?.trim(),
     )
     .map((part) => part.text)
     .join("\n\n");
+
+  return sanitizeMessageText(raw);
+}
+
+/**
+ * Parse "Called the X tool with the following input: {JSON}" patterns
+ * from raw text parts and return synthetic ToolPart objects so they
+ * render as proper ToolCallItems (with icons, labels, etc.).
+ */
+function extractInlineToolCalls(parts: Part[]): ToolPart[] {
+  const raw = parts
+    .filter(
+      (part): part is Part & { type: "text"; text: string } =>
+        part.type === "text" && "text" in part && !!part.text?.trim(),
+    )
+    .map((part) => part.text)
+    .join("\n\n");
+
+  const pattern =
+    /(?:I\s+)?[Cc]alled\s+the\s+(\w+)\s+tool\s+with\s+the\s+following\s+input:\s*(\{[\s\S]*?\})/g;
+  const results: ToolPart[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(raw)) !== null) {
+    const toolName = match[1]!;
+    const jsonStr = match[2]!;
+    let input: Record<string, unknown> = {};
+    try {
+      input = JSON.parse(jsonStr);
+    } catch {
+      // If JSON parsing fails, try to extract key fields with regex
+      const fileMatch = jsonStr.match(/"(?:filePath|file)":\s*"([^"]+)"/);
+      const cmdMatch = jsonStr.match(/"(?:command|cmd)":\s*"([^"]+)"/);
+      const patternMatch = jsonStr.match(/"pattern":\s*"([^"]+)"/);
+      if (fileMatch) input = { filePath: fileMatch[1] };
+      else if (cmdMatch) input = { command: cmdMatch[1] };
+      else if (patternMatch) input = { pattern: patternMatch[1] };
+    }
+    results.push({
+      id: `synthetic-${toolName}-${results.length}`,
+      sessionID: "",
+      messageID: "",
+      type: "tool",
+      callID: `synthetic-${toolName}-${results.length}`,
+      tool: toolName,
+      state: {
+        status: "completed",
+        input,
+        title: toolName,
+        metadata: {},
+        time: { start: 0, end: 0 },
+      },
+    } as ToolPart);
+  }
+
+  return results;
 }
 
 function getAssistantError(message: MessageWithParts) {
@@ -620,6 +804,38 @@ function PermissionRequestForm({
   );
 }
 
+const TodoItem = memo(function TodoItem({
+  todo,
+}: {
+  todo: { content: string; status: string; priority?: string };
+}) {
+  const statusIcon =
+    todo.status === "completed" ? (
+      <CheckIcon size="11px" className="text-success" />
+    ) : todo.status === "in_progress" ? (
+      <span className="inline-block size-[11px] rounded-full border-2 border-warning animate-pulse" />
+    ) : (
+      <span className="inline-block size-[11px] rounded-full border-2 border-muted-fg/40" />
+    );
+
+  return (
+    <div className="flex items-start gap-1.5 py-0.5">
+      <span className="mt-px shrink-0">{statusIcon}</span>
+      <span
+        className={
+          todo.status === "completed"
+            ? "line-through opacity-50"
+            : todo.status === "in_progress"
+              ? "text-fg"
+              : "opacity-70"
+        }
+      >
+        {todo.content}
+      </span>
+    </div>
+  );
+});
+
 const ToolCallItem = memo(function ToolCallItem({
   part,
   port,
@@ -636,13 +852,186 @@ const ToolCallItem = memo(function ToolCallItem({
   onQuestionResolved: (requestId: string) => void;
 }) {
   const { icon, label, details } = formatToolCall(part);
-  const isQuestionTool = (part.tool || "").toLowerCase() === "question";
+  const toolName = (part.tool || "").toLowerCase();
+  const isQuestionTool = toolName === "question";
+  const isTodoTool = toolName === "todowrite";
+  const isBashTool = toolName === "bash" || toolName === "mcp_bash";
+  const isTaskTool = toolName === "task" || toolName === "mcp_task";
   const questions = isQuestionTool ? parseToolQuestions(part) : [];
   const hasQuestions = questions.length > 0;
   const isCompleted = part.state.status === "completed";
   const isError = part.state.status === "error";
   const isPending =
     part.state.status === "pending" || part.state.status === "running";
+  const [todoExpanded, setTodoExpanded] = useState(false);
+  const [bashExpanded, setBashExpanded] = useState(false);
+
+  if (isTodoTool) {
+    const input = (part.state?.input || {}) as Record<string, unknown>;
+    const todos = Array.isArray(input.todos)
+      ? (input.todos as { content: string; status: string; priority?: string }[])
+      : [];
+
+    return (
+      <div
+        className={`rounded-md border px-3 py-2 text-xs ${
+          isError
+            ? "border-danger/40 bg-danger-subtle/30"
+            : isCompleted
+              ? "border-border bg-muted/25"
+              : "border-warning/40 bg-warning/10"
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => setTodoExpanded((v) => !v)}
+          className={`font-mono text-xs flex items-center gap-1.5 min-w-0 w-full text-left cursor-pointer ${
+            isError
+              ? "text-danger"
+              : isCompleted
+                ? "text-muted-fg"
+                : isPending
+                  ? "text-warning"
+                  : "text-fg"
+          }`}
+        >
+          <span className="opacity-60 shrink-0">
+            {todoExpanded ? (
+              <ChevronDownIcon size="12px" />
+            ) : (
+              <ChevronRightIcon size="12px" />
+            )}
+          </span>
+          <span className="opacity-60 shrink-0">{icon}</span>
+          <span className="truncate">{label}</span>
+          {details && <span className="opacity-60 shrink-0">{details}</span>}
+          {isPending && <span className="animate-pulse shrink-0">...</span>}
+        </button>
+
+        {todoExpanded && todos.length > 0 && (
+          <div className="mt-1.5 ml-1 space-y-0.5 font-mono text-xs">
+            {todos.map((todo, i) => (
+              <TodoItem key={i} todo={todo} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (isTaskTool) {
+    const state = part.state as Record<string, unknown>;
+    const meta = (state.metadata || {}) as Record<string, unknown>;
+    const subSessionId = typeof meta.sessionId === "string" ? meta.sessionId : "";
+
+    const content = (
+      <div
+        className={`font-mono text-xs flex items-center gap-1.5 py-0.5 min-w-0 ${
+          isError
+            ? "text-danger"
+            : isCompleted
+              ? "text-muted-fg"
+              : isPending
+                ? "text-warning"
+                : "text-fg"
+        }`}
+      >
+        <span className="opacity-60 shrink-0">{icon}</span>
+        <span className="truncate">{label}</span>
+        {details && <span className="opacity-60 shrink-0">{details}</span>}
+        {isPending && <span className="animate-pulse shrink-0">...</span>}
+      </div>
+    );
+
+    if (subSessionId) {
+      return (
+        <Link
+          to="/session/$id"
+          params={{ id: subSessionId }}
+          className="block hover:bg-muted/40 rounded-md -mx-1 px-1 transition-colors"
+        >
+          {content}
+        </Link>
+      );
+    }
+
+    return content;
+  }
+
+  if (isBashTool) {
+    const state = part.state as Record<string, unknown>;
+    const input = (state.input || {}) as Record<string, unknown>;
+    const fullCommand = String(input.command || input.cmd || "");
+    const output = typeof state.output === "string" ? state.output : "";
+    const errorMsg = typeof state.error === "string" ? state.error : "";
+    const hasContent = !!(fullCommand || output || errorMsg);
+
+    return (
+      <div
+        className={`rounded-md border px-3 py-2 text-xs ${
+          isError
+            ? "border-danger/40 bg-danger-subtle/30"
+            : isCompleted
+              ? "border-border bg-muted/25"
+              : "border-warning/40 bg-warning/10"
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => hasContent && setBashExpanded((v) => !v)}
+          className={`font-mono text-xs flex items-center gap-1.5 min-w-0 w-full text-left ${hasContent ? "cursor-pointer" : "cursor-default"} ${
+            isError
+              ? "text-danger"
+              : isCompleted
+                ? "text-muted-fg"
+                : isPending
+                  ? "text-warning"
+                  : "text-fg"
+          }`}
+        >
+          {hasContent && (
+            <span className="opacity-60 shrink-0">
+              {bashExpanded ? (
+                <ChevronDownIcon size="12px" />
+              ) : (
+                <ChevronRightIcon size="12px" />
+              )}
+            </span>
+          )}
+          <span className="opacity-60 shrink-0">{icon}</span>
+          <span className="truncate">{label}</span>
+          {details && <span className="opacity-60 shrink-0">{details}</span>}
+          {isPending && <span className="animate-pulse shrink-0">...</span>}
+        </button>
+
+        {bashExpanded && (
+          <div className="mt-2 space-y-2">
+            {fullCommand && (
+              <pre className="whitespace-pre-wrap break-all rounded bg-bg/80 p-2 text-[11px] leading-relaxed text-fg/90 border border-border/50 overflow-x-auto max-h-[300px] overflow-y-auto">
+                <code>{fullCommand}</code>
+              </pre>
+            )}
+            {output && (
+              <div>
+                <div className="text-[10px] uppercase tracking-wide text-muted-fg/60 mb-1">output</div>
+                <pre className="whitespace-pre-wrap break-all rounded bg-bg/80 p-2 text-[11px] leading-relaxed text-fg/70 border border-border/50 overflow-x-auto max-h-[400px] overflow-y-auto">
+                  <code>{output}</code>
+                </pre>
+              </div>
+            )}
+            {errorMsg && (
+              <div>
+                <div className="text-[10px] uppercase tracking-wide text-danger/60 mb-1">error</div>
+                <pre className="whitespace-pre-wrap break-all rounded bg-danger/5 p-2 text-[11px] leading-relaxed text-danger/80 border border-danger/30 overflow-x-auto max-h-[300px] overflow-y-auto">
+                  <code>{errorMsg}</code>
+                </pre>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
 
   if (hasQuestions) {
     return (
@@ -727,7 +1116,9 @@ const MessageItem = memo(function MessageItem({
   const textContent = getMessageContent(message.parts);
   const isAssistant = message.info.role === "assistant";
   const messageError = isAssistant ? getAssistantError(message) : null;
-  const toolCalls = message.parts.filter(isToolPart);
+  const realToolCalls = message.parts.filter(isToolPart);
+  const inlineToolCalls = extractInlineToolCalls(message.parts);
+  const toolCalls = [...inlineToolCalls, ...realToolCalls];
   const messagePermissions = pendingPermissions.filter(
     (perm) => perm.tool?.messageID === message.info.id,
   );
@@ -742,7 +1133,7 @@ const MessageItem = memo(function MessageItem({
           ) : (
             <IconUser size="16px" className="shrink-0 mt-1" />
           )}
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             {!isAssistant && message.isQueued && (
               <Badge intent="warning" className="mb-1">
                 Queued
@@ -752,7 +1143,7 @@ const MessageItem = memo(function MessageItem({
               className={`prose prose-sm dark:prose-invert max-w-none overflow-x-hidden ${!isAssistant ? "text-muted-fg" : ""}`}
             >
               {textContent && (
-                <Markdown remarkPlugins={[remarkGfm]}>{textContent}</Markdown>
+                <Markdown remarkPlugins={[remarkGfm, remarkBreaks]}>{textContent}</Markdown>
               )}
             </div>
             {messageError && (
@@ -833,6 +1224,26 @@ function SessionPage() {
   const sessions: Session[] = sessionsData ?? [];
   const agents: Agent[] = agentsData ?? [];
   const currentSession = sessions.find((s) => s.id === sessionId);
+  const isSubagentSession = !!currentSession?.parentID;
+
+  const subagentStats = useMemo(() => {
+    if (!isSubagentSession) return null;
+    let totalCost = 0;
+    let lastContextTokens = 0;
+    for (const msg of sessionMessages) {
+      if (msg.type !== "assistant") continue;
+      const am = msg as SessionMessageAssistant;
+      totalCost += am.cost ?? 0;
+      if (am.tokens) {
+        const t = am.tokens;
+        lastContextTokens =
+          t.input + t.output + t.reasoning + t.cache.read + t.cache.write;
+      }
+    }
+    const modelId = currentSession?.model?.id;
+    const displayModel = modelId ? stripModelDateSuffix(modelId) : undefined;
+    return { contextTokens: lastContextTokens, cost: totalCost, displayModel };
+  }, [isSubagentSession, sessionMessages, currentSession?.model?.id]);
 
   useEffect(() => {
     if (currentSession?.title) {
@@ -892,6 +1303,20 @@ function SessionPage() {
 
     return isSubmitting || statusActive || hasOpenAssistant || hasPendingUser;
   }, [isSubmitting, sessionMessages, sessionStatus?.type]);
+
+  const abortSession = useAbortSession();
+  const handleAbort = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      await abortSession(sessionId);
+      mutateSessionMessages(port, sessionId, provider);
+      mutateSessionStatuses();
+    } catch (error) {
+      setSendError(
+        error instanceof Error ? error.message : "Failed to stop run",
+      );
+    }
+  }, [sessionId, abortSession, port, provider, mutateSessionStatuses]);
 
   const pendingPermissions = useMemo(
     () =>
@@ -1145,7 +1570,7 @@ function SessionPage() {
   }, [port, provider, sending, sessionId]);
 
   return (
-    <div className="flex h-full flex-col -m-4">
+    <div className="flex h-[calc(100%+2rem)] flex-col -m-4">
       <div
         className="flex-1 overflow-auto overflow-x-hidden"
         ref={chatContainerRef}
@@ -1210,7 +1635,43 @@ function SessionPage() {
         )}
       </div>
 
-      <div className="border-t border-border p-4 shrink-0 relative">
+      {isSubagentSession ? (
+        <div className="border-t border-border px-4 py-3 shrink-0">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-xs text-muted-fg font-mono">
+              <IconBadgeSparkle size="14px" className="shrink-0" />
+              <span>{currentSession?.agent || "subagent"}</span>
+              {subagentStats?.displayModel && (
+                <>
+                  <span className="text-border">·</span>
+                  <span>{subagentStats.displayModel}</span>
+                </>
+              )}
+              {(subagentStats?.contextTokens ?? 0) > 0 && (
+                <>
+                  <span className="text-border">·</span>
+                  <span>{formatTokens(subagentStats!.contextTokens)} ctx</span>
+                </>
+              )}
+              {(subagentStats?.cost ?? 0) > 0 && (
+                <>
+                  <span className="text-border">·</span>
+                  <span>{formatCost(subagentStats!.cost)}</span>
+                </>
+              )}
+            </div>
+            <Link
+              to="/session/$id"
+              params={{ id: currentSession!.parentID! }}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted/30 px-3 py-1.5 text-xs font-medium text-fg hover:bg-muted/60 transition-colors"
+            >
+              <ArrowLeftIcon size="12px" />
+              Parent
+            </Link>
+          </div>
+        </div>
+      ) : (
+      <div className="border-t border-border px-4 pt-4 pb-4 shrink-0 relative">
         <FileMentionPopover
           isOpen={fileMention.isOpen}
           searchQuery={fileMention.searchQuery}
@@ -1292,24 +1753,33 @@ function SessionPage() {
               className="min-h-32 max-h-32 w-full resize-none overflow-y-auto pr-14 pb-12"
               rows={5}
             />
-            <Button
-              type="submit"
-              isDisabled={!input.trim() || sending}
-              isCircle
-              size="sq-sm"
-              aria-label={sending ? "Sending message" : "Send message"}
-              className="absolute right-3 bottom-3"
-            >
-              {sending ? (
+            {sending ? (
+              <Button
+                type="button"
+                onPress={handleAbort}
+                isCircle
+                size="sq-sm"
+                aria-label="Stop run"
+                className="absolute right-3 bottom-3"
+              >
                 <span className="grid size-4 place-items-center">
-                  <Loader className="size-4" aria-label="Sending message" />
+                  <StopIcon size="14px" className="fill-current" />
                 </span>
-              ) : (
+              </Button>
+            ) : (
+              <Button
+                type="submit"
+                isDisabled={!input.trim()}
+                isCircle
+                size="sq-sm"
+                aria-label="Send message"
+                className="absolute right-3 bottom-3"
+              >
                 <span className="grid size-4 place-items-center">
                   <SendIcon size="16px" />
                 </span>
-              )}
-            </Button>
+              </Button>
+            )}
           </div>
           <div className="mt-3 flex items-center justify-end gap-2">
             {supportsAgentSelection && <AgentSelect sessionId={sessionId} />}
@@ -1317,6 +1787,7 @@ function SessionPage() {
           </div>
         </form>
       </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/routes/_app/session/$id.tsx
+++ b/apps/web/src/routes/_app/session/$id.tsx
@@ -215,6 +215,76 @@ function parseToolQuestions(part: ToolPart): QuestionInfo[] {
     .filter((q) => !!q.question);
 }
 
+type QuestionAnswers = { chosen: string[]; typed: string[] };
+
+/**
+ * Parse the submitted answers from a completed question tool part.
+ *
+ * Answers can be stored in several shapes depending on the backend:
+ *  - `state.metadata.answers` as string[][] indexed by question position
+ *    (native opencode)
+ *  - `state.input.answers` as a record keyed by question text ->
+ *    string (single/custom) | string[] (multi) (Claude backend)
+ *  - `state.input.answers` as string[][] indexed by question position (fallback)
+ *
+ * Returns one entry per question split into `chosen` (matches an option label)
+ * and `typed` (freeform/custom answers that match no option). Returns null when
+ * no answers are present (e.g. codex), so the caller can fall back to the
+ * plain read-only list.
+ */
+function parseQuestionAnswers(
+  part: ToolPart,
+  questions: QuestionInfo[],
+): QuestionAnswers[] | null {
+  const state = (part.state || {}) as Record<string, unknown>;
+  const metadata = (state.metadata || {}) as Record<string, unknown>;
+  const input = (state.input || {}) as Record<string, unknown>;
+
+  const rawMeta = metadata.answers;
+  const rawInput = input.answers;
+
+  const metaArray = Array.isArray(rawMeta) ? (rawMeta as unknown[]) : null;
+  const inputArray = Array.isArray(rawInput) ? (rawInput as unknown[]) : null;
+  const inputRecord =
+    !inputArray && rawInput && typeof rawInput === "object"
+      ? (rawInput as Record<string, unknown>)
+      : null;
+
+  if (!metaArray && !inputArray && !inputRecord) return null;
+
+  const toStringArray = (value: unknown): string[] => {
+    if (Array.isArray(value)) {
+      return value
+        .map((v) => (typeof v === "string" ? v : String(v ?? "")))
+        .filter((v) => v.length > 0);
+    }
+    if (typeof value === "string") {
+      return value.length > 0 ? [value] : [];
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      return [String(value)];
+    }
+    return [];
+  };
+
+  return questions.map((q, idx) => {
+    let rawValue: unknown;
+    if (metaArray) rawValue = metaArray[idx];
+    else if (inputRecord) rawValue = inputRecord[q.question];
+    else rawValue = inputArray?.[idx];
+
+    const values = toStringArray(rawValue);
+    const optionLabels = new Set(q.options.map((opt) => opt.label));
+    const chosen: string[] = [];
+    const typed: string[] = [];
+    for (const value of values) {
+      if (optionLabels.has(value)) chosen.push(value);
+      else typed.push(value);
+    }
+    return { chosen, typed };
+  });
+}
+
 function formatToolCall(part: ToolPart): {
   icon: React.ReactNode;
   label: string;
@@ -356,48 +426,99 @@ function formatToolCall(part: ToolPart): {
 function QuestionDisplay({
   questions,
   partKey,
+  answers,
 }: {
   questions: QuestionInfo[];
   partKey: string;
+  answers?: QuestionAnswers[] | null;
 }) {
   return (
     <>
-      {questions.map((q, idx) => (
-        <div key={`${partKey}-q-${idx}`} className="space-y-1">
-          {(q.header || q.multiple) && (
-            <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-muted-fg">
-              {q.header && <span>{q.header}</span>}
-              {q.multiple && (
-                <span className="rounded border border-warning/50 bg-warning/10 px-1.5 py-0.5 text-[10px] font-medium text-warning">
-                  Multi-select
-                </span>
-              )}
-            </div>
-          )}
-          <p className="text-xs leading-relaxed">{q.question}</p>
+      {questions.map((q, idx) => {
+        const answer = answers?.[idx];
+        const chosen = answer ? new Set(answer.chosen) : null;
+        const typed = answer?.typed ?? [];
+        const isAnswered = !!answer && (answer.chosen.length > 0 || typed.length > 0);
 
-          {q.options.length > 0 && (
-            <ul className="space-y-1 ml-3 list-disc text-muted-fg">
-              {q.options.map((opt, optIdx) => (
-                <li key={`opt-${idx}-${optIdx}`}>
-                  <span className="text-fg">{opt.label}</span>
-                  {opt.description && (
-                    <span className="text-muted-fg"> - {opt.description}</span>
-                  )}
-                </li>
+        return (
+          <div key={`${partKey}-q-${idx}`} className="space-y-1.5">
+            {(q.header || q.multiple) && (
+              <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-muted-fg">
+                {q.header && <span>{q.header}</span>}
+                {q.multiple && (
+                  <span className="rounded border border-warning/50 bg-warning/10 px-1.5 py-0.5 text-[10px] font-medium text-warning">
+                    Multi-select
+                  </span>
+                )}
+              </div>
+            )}
+            <p className="text-xs leading-relaxed">{q.question}</p>
+
+            {q.options.length > 0 &&
+              (chosen ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {q.options.map((opt, optIdx) => {
+                    const isSelected = chosen.has(opt.label);
+                    return (
+                      <span
+                        key={`opt-${idx}-${optIdx}`}
+                        className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
+                          isSelected
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-border/60 bg-bg text-muted-fg/60"
+                        }`}
+                      >
+                        {isSelected && <CheckIcon size="12px" />}
+                        <span>{opt.label}</span>
+                        {opt.description && (
+                          <span className="opacity-60"> - {opt.description}</span>
+                        )}
+                      </span>
+                    );
+                  })}
+                </div>
+              ) : (
+                <ul className="space-y-1 ml-3 list-disc text-muted-fg">
+                  {q.options.map((opt, optIdx) => (
+                    <li key={`opt-${idx}-${optIdx}`}>
+                      <span className="text-fg">{opt.label}</span>
+                      {opt.description && (
+                        <span className="text-muted-fg"> - {opt.description}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
               ))}
-            </ul>
-          )}
 
-          {(q.multiple || q.custom) && (
-            <div className="text-[11px] text-muted-fg">
-              {q.multiple && "You can select multiple options"}
-              {q.multiple && q.custom && " | "}
-              {q.custom && "Custom answer allowed"}
-            </div>
-          )}
-        </div>
-      ))}
+            {typed.length > 0 && (
+              <div className="space-y-1">
+                <div className="text-[11px] uppercase tracking-wide text-muted-fg">
+                  Your answer
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {typed.map((value, tIdx) => (
+                    <span
+                      key={`typed-${idx}-${tIdx}`}
+                      className="inline-flex items-center gap-1 rounded-md border border-primary bg-primary/10 px-2 py-1 text-xs text-primary"
+                    >
+                      <CheckIcon size="12px" />
+                      <span>{value}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {!isAnswered && (q.multiple || q.custom) && (
+              <div className="text-[11px] text-muted-fg">
+                {q.multiple && "You can select multiple options"}
+                {q.multiple && q.custom && " | "}
+                {q.custom && "Custom answer allowed"}
+              </div>
+            )}
+          </div>
+        );
+      })}
     </>
   );
 }
@@ -1086,6 +1207,7 @@ const ToolCallItem = memo(function ToolCallItem({
             <QuestionDisplay
               questions={questions}
               partKey={part.callID || part.id}
+              answers={parseQuestionAnswers(part, questions)}
             />
           </div>
         )}

--- a/apps/web/src/server/opencode/[port]/session/[id]/fork.ts
+++ b/apps/web/src/server/opencode/[port]/session/[id]/fork.ts
@@ -1,0 +1,26 @@
+import { z } from "zod/v4";
+import { defineHandler } from "nitro/h3";
+import { getOpencodeClient } from "../../../../lib/opencode-client";
+import {
+  parsePort,
+  parseRouteParam,
+  parseBody,
+} from "../../../../lib/validation";
+
+const forkBodySchema = z.object({
+  messageID: z.string().optional(),
+});
+
+export default defineHandler(async (event) => {
+  const port = parsePort(event);
+  const id = parseRouteParam(event, "id");
+  const body = await parseBody(event, forkBodySchema);
+
+  const client = getOpencodeClient(port);
+  const result = await client.session.fork({
+    sessionID: id,
+    messageID: body.messageID,
+  });
+
+  return result.data;
+});

--- a/apps/web/src/server/opencode/[port]/session/[id]/revert.ts
+++ b/apps/web/src/server/opencode/[port]/session/[id]/revert.ts
@@ -1,0 +1,35 @@
+import { z } from "zod/v4";
+import { HTTPError, defineHandler } from "nitro/h3";
+import { formatErrorMessage } from "@/lib/error-message";
+import { getOpencodeClient } from "../../../../lib/opencode-client";
+import {
+  parsePort,
+  parseRouteParam,
+  parseBody,
+} from "../../../../lib/validation";
+
+const revertBodySchema = z.object({
+  messageID: z.string().min(1),
+  partID: z.string().optional(),
+});
+
+export default defineHandler(async (event) => {
+  const port = parsePort(event);
+  const id = parseRouteParam(event, "id");
+  const body = await parseBody(event, revertBodySchema);
+
+  const client = getOpencodeClient(port);
+  try {
+    const result = await client.session.revert({
+      sessionID: id,
+      messageID: body.messageID,
+      partID: body.partID,
+    });
+
+    return result.data;
+  } catch (error) {
+    throw new HTTPError(formatErrorMessage(error, "Failed to revert session"), {
+      status: 500,
+    });
+  }
+});

--- a/apps/web/src/stores/draft-store.ts
+++ b/apps/web/src/stores/draft-store.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+
+interface DraftState {
+  drafts: Record<string, string | undefined>;
+  setDraft: (sessionId: string, text: string) => void;
+  consumeDraft: (sessionId: string) => string | undefined;
+}
+
+export const useDraftStore = create<DraftState>((set, get) => ({
+  drafts: {},
+  setDraft: (sessionId, text) =>
+    set((state) => ({
+      drafts: { ...state.drafts, [sessionId]: text },
+    })),
+  consumeDraft: (sessionId) => {
+    const text = get().drafts[sessionId];
+    if (text !== undefined) {
+      set((state) => {
+        const { [sessionId]: _, ...rest } = state.drafts;
+        return { drafts: rest };
+      });
+    }
+    return text;
+  },
+}));

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "react-aria-components": "^1.17.0",
         "react-dom": "^19.2.6",
         "react-markdown": "^10.1.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "swr": "^2.4.1",
@@ -1506,6 +1507,8 @@
 
     "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
 
+    "mdast-util-newline-to-break": ["mdast-util-newline-to-break@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-find-and-replace": "^3.0.0" } }, "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
@@ -1819,6 +1822,8 @@
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
+
+    "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
 
     "remark-frontmatter": ["remark-frontmatter@5.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-frontmatter": "^2.0.0", "micromark-extension-frontmatter": "^2.0.0", "unified": "^11.0.0" } }, "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ=="],
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "chrome-devtools": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "chrome-devtools-mcp@latest"
+      ],
+      "enabled": true
+    }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -6,7 +6,8 @@
       "command": [
         "npx",
         "-y",
-        "chrome-devtools-mcp@latest"
+        "chrome-devtools-mcp@latest",
+        "--isolated"
       ],
       "enabled": true
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "check-types": "turbo run check-types"
+    "check-types": "turbo run check-types",
+    "server": "scripts/server.sh",
+    "server:start": "scripts/server.sh start",
+    "server:stop": "scripts/server.sh stop",
+    "server:restart": "scripts/server.sh restart",
+    "server:status": "scripts/server.sh status"
   },
   "workspaces": [
     "apps/*",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",
+    "release:local": "turbo run build && scripts/server.sh restart",
     "server": "scripts/server.sh",
     "server:start": "scripts/server.sh start",
     "server:stop": "scripts/server.sh stop",

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT=4096
+PID_FILE="/tmp/portal-web.pid"
+LOG_FILE="/tmp/portal-web.log"
+
+# Resolve repo root from this script's location so it works from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WEB_DIR="$ROOT_DIR/apps/web"
+
+port_pids() {
+  lsof -ti "tcp:$PORT" 2>/dev/null || true
+}
+
+is_running() {
+  [ -n "$(port_pids)" ]
+}
+
+stop() {
+  local pids
+  pids="$(port_pids)"
+
+  if [ -f "$PID_FILE" ]; then
+    pids="$pids $(cat "$PID_FILE" 2>/dev/null || true)"
+  fi
+
+  pids="$(echo "$pids" | tr ' ' '\n' | sort -u | grep -v '^$' || true)"
+
+  if [ -z "$pids" ]; then
+    echo "No server running on port $PORT."
+    rm -f "$PID_FILE"
+    return 0
+  fi
+
+  echo "Stopping server (PIDs: $(echo "$pids" | tr '\n' ' '))..."
+  # shellcheck disable=SC2086
+  kill $pids 2>/dev/null || true
+
+  # Wait up to 5s for graceful shutdown, then force kill.
+  for _ in 1 2 3 4 5; do
+    is_running || break
+    sleep 1
+  done
+
+  if is_running; then
+    echo "Force killing remaining processes..."
+    # shellcheck disable=SC2086
+    kill -9 $(port_pids) 2>/dev/null || true
+  fi
+
+  rm -f "$PID_FILE"
+  echo "Stopped."
+}
+
+start() {
+  if is_running; then
+    echo "Port $PORT already in use. Stopping existing server first..."
+    stop
+  fi
+
+  echo "Starting server on port $PORT..."
+  cd "$WEB_DIR"
+  PORT="$PORT" nohup bun run preview > "$LOG_FILE" 2>&1 &
+  echo $! > "$PID_FILE"
+  echo "Started (PID: $(cat "$PID_FILE"))."
+  echo "Logs: $LOG_FILE"
+}
+
+status() {
+  if is_running; then
+    echo "Server is RUNNING on port $PORT (PIDs: $(port_pids | tr '\n' ' '))."
+    [ -f "$PID_FILE" ] && echo "PID file: $PID_FILE ($(cat "$PID_FILE"))"
+    echo "Logs: $LOG_FILE"
+  else
+    echo "Server is STOPPED (port $PORT free)."
+  fi
+}
+
+case "${1:-}" in
+  start)   start ;;
+  stop)    stop ;;
+  restart) stop; start ;;
+  status)  status ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "ui": "tui",
+  "ui": "stream",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
# 1. Problem and Solution

## Context
The session view and sidebar lacked common controls for managing a run and recovering from mistakes. There was no way to fork a session, revert a message, carry draft input into a new session, or resolve a deep-linked session to the running instance that owns it. Submitted answers from the question tool were also not rendered back to the user, and usage figures were shown as raw numbers.

This change adds session fork/revert, deep-link instance resolution, draft carry-over, question-answer rendering, and supporting UI/formatting work, plus local server helper scripts.

## Implementation Flow
```
Open deep link /session/:id
        │
        └── useResolveSessionInstance(id)
                    │
                    ├── query each running instance for the session
                    ├── found → bind session to that instance's [port]
                    └── not found → surface unresolved state

Session actions menu
        │
        ├── Fork  → POST /opencode/[port]/session/[id]/fork   → client.session.fork()
        │             └── draft-store carries current input into the new session
        │
        └── Revert → POST /opencode/[port]/session/[id]/revert → client.session.revert()

Run in progress (sending)
        │
        └── Stop button (bottom-right of input)
                    │
                    └── opens confirm popover
                              ├── cancel → keep running
                              └── confirm → useAbortSession() → handleAbort() → run stops

Question tool part
        │
        ├── [OLD] render prompt only
        └── [NEW] parseQuestionAnswers() → QuestionAnswers renders submitted answers

Open a subagent session (currentSession.parentID set)
        │
        └── isSubagentSession → composer replaced by read-only footer
                    ├── agent · model · formatTokens(ctx) ctx · formatCost(cost)
                    └── "Parent" back button → Link to parent session
```

# 2. Key Changes
- Session fork and revert: new Nitro server handlers `apps/web/src/server/opencode/[port]/session/[id]/fork.ts` and `revert.ts` calling the opencode client, exposed through `useForkSession`/`useRevertSession` in `use-opencode.ts`, wired to an actions menu in `routes/_app/session/$id.tsx`.
- Deep-link instance resolution: `hooks/use-resolve-session-instance.ts` resolves which running instance owns a session id so deep links bind to the correct port.
- Draft carry-over: `stores/draft-store.ts` (zustand) carries input text into a forked session.
- Question answers: `parseQuestionAnswers()` plus a `QuestionAnswers` renderer display submitted answers in the question tool output.
- Stop a running session: while a run is in progress, a circular Stop button appears at the bottom-right of the input. It opens a confirmation popover, and confirming calls the new `useAbortSession` hook (`handleAbort`) to abort the run and refresh message/status state. Errors surface as "Failed to stop run".
- Subagent view and back button: a session with `parentID` set renders as a read-only subagent view (`isSubagentSession`), replacing the composer with a footer showing the agent name, model, context tokens, and cost (`subagentStats`), plus a right-aligned "Parent" button (`ArrowLeftIcon`) that links back to the parent session.
- Sidebar/session UI: active-session highlight, new lucide icons (`StopIcon`, `UndoIcon`, `ArrowLeftIcon`, git-branch, ellipsis), and `lib/format.ts` helpers (`formatTokens`, `formatCost`) for token/cost display.
- Tooling: `scripts/server.sh` and npm `server:*`/`release:local` scripts; turbo UI switched to stream mode;

# 3. Impact and Scope
- Scope is the `apps/web` frontend plus repo tooling; no database or external API contract changes.
- New server routes are additive under the existing `opencode/[port]/session/[id]` namespace and call existing client methods (`session.fork`, `session.revert`).
- Behavioral change: deep-linked sessions now resolve to a specific instance before rendering; sessions can be forked/reverted from the UI.
- No backward-incompatible changes to existing routes. Risk is contained to the session view and sidebar.

# 4. Testing
Verified manually in a mobile viewport (390x844) against a local build on port 4096, using a fresh session for each scenario.

- [x] Fork a session and confirm current input text is carried into the new session
- [x] Revert a message and confirm the revert request is sent and session state refreshes
- [x] Submit answers via the question tool and confirm they render in the tool output
- [x] Confirm cost values render via `formatCost`
- [x] Start a run, click the Stop button, confirm the popover, and verify the run aborts
- [x] Confirm active session is highlighted in the sidebar
- [x] Open a subagent session and confirm the read-only footer (agent, model, ctx, cost) and "Parent" back button
- [x] Click the "Parent" button and confirm it navigates to the parent session
- [x] Open a deep link to a session id and confirm it binds to the instance that owns it
- [x] Cancel the Stop confirmation popover and verify the run keeps going

Note on revert: the revert request is sent (`POST /session/:id/revert` returns 200 and message/session/status queries refetch). This UI does not yet render a distinct "reverted" visual state, so the message list still displays the existing messages after the call.

## Evidence

<details>
<summary>Instance picker and new session (mobile)</summary>

![instances picker](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/01-instances-mobile.png)
![empty new session](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/02-new-session-empty-mobile.png)

</details>

<details>
<summary>Stop button: in-progress run, confirmation popover, aborted</summary>

Circular Stop button appears at the bottom-right of the input while a run is in progress.

![run in progress with stop button](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/03-run-in-progress-stop-button-mobile.png)

Confirmation popover ("Stop this run?") with "Keep running" and "Stop run".

![stop confirmation popover](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/04-stop-confirmation-popover-mobile.png)

After confirming, the run is aborted ("Aborted") and the cost renders via `formatCost`.

![run aborted](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/05-run-aborted-mobile.png)

</details>

<details>
<summary>Fork and revert: message actions menu, draft carry-over, sidebar</summary>

Per-message "Message actions" menu exposing Fork and Revert.

![message actions menu](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/06-message-actions-fork-revert-mobile.png)

Forking opens a new session with the current input text carried over (draft-store).

![forked session with draft carry-over](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/07-forked-session-draft-carryover-mobile.png)

The forked session appears in the sidebar above its parent, with the active session highlighted.

![sidebar fork and active highlight](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/08-sidebar-fork-active-highlight-mobile.png)

</details>

<details>
<summary>Question tool: prompt and rendered submitted answer</summary>

Question tool renders the header, body, options, free-text box, and a disabled "Submit Answers" button.

![question prompt](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/09-question-prompt-mobile.png)

After choosing "Green" and submitting, the selected answer renders back in the tool output.

![question answer rendered](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/10-question-answer-rendered-mobile.png)

Selected option highlighted (checkmark + border), unselected options dimmed.

![question answer detail](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/11-revert-mobile.png)

</details>

<details>
<summary>Subagent view and "Parent" back button</summary>

A subagent session (one with a parent) is read-only: the composer is replaced by a footer showing the agent, model, context tokens, and cost, with a "Parent" back button.

![subagent view with parent back button](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/12-subagent-view-parent-back-mobile.png)

Clicking "Parent" navigates back to the parent session.

![parent session after back](https://raw.githubusercontent.com/tranphucbol/portal/pr-evidence/improve_ui/images/13-parent-session-after-back-mobile.png)

</details>
