### PR TITLE
Fix horizontal scrolling of code blocks on mobile

### DIFF
--- a/apps/web/src/routes/_app/session/$id.tsx
+++ b/apps/web/src/routes/_app/session/$id.tsx
@@ -742,7 +742,7 @@ const MessageItem = memo(function MessageItem({
           ) : (
             <IconUser size="16px" className="shrink-0 mt-1" />
           )}
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             {!isAssistant && message.isQueued && (
               <Badge intent="warning" className="mb-1">
                 Queued


### PR DESCRIPTION
On phones, code blocks in the session view get clipped instead of scrolling. The pre has overflow-x: auto, but its flex-1 ancestor has the default min-width: auto, so the column grows to the code's width and the pre never actually overflows; the extra width just gets clipped by an outer overflow-x-hidden.

min-w-0 lets the column shrink so the pre becomes a real scroll container. Tested at 390px viewport width: the block scrolls and the page width stays put.
