### PR TITLE
feat(web): support Basic Auth for OpenCode backend discovery and client

### DIFF
--- a/apps/web/src/server/instances.ts
+++ b/apps/web/src/server/instances.ts
@@ -224,6 +224,16 @@ function formatUrlHost(host: string): string {
   return host.includes(":") ? `[${host}]` : host;
 }
 
+function getAuthHeaders(): Record<string, string> | undefined {
+  const username = process.env.OPENCODE_SERVER_USERNAME;
+  const password = process.env.OPENCODE_SERVER_PASSWORD;
+  if (username && password) {
+    return {
+      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+    };
+  }
+}
+
 async function fetchJson<T>(
   url: string,
   options: { headers?: HeadersInit; timeoutMs?: number } = {},
@@ -239,6 +249,7 @@ async function fetchJson<T>(
       headers: {
         Accept: "application/json",
         ...options.headers,
+        ...getAuthHeaders(),
       },
       signal: controller.signal,
     });
@@ -629,9 +640,10 @@ export default defineHandler(async () => {
       version: "claude sdk",
       sessionStats: null,
       state: "running" as const,
-      status: webRunning && instance.startedAt
-        ? `Managed by OpenPortal since ${new Date(instance.startedAt).toLocaleString()}`
-        : "Registered by openportal run",
+      status:
+        webRunning && instance.startedAt
+          ? `Managed by OpenPortal since ${new Date(instance.startedAt).toLocaleString()}`
+          : "Registered by openportal run",
     };
   });
 

--- a/apps/web/src/server/lib/opencode-client.ts
+++ b/apps/web/src/server/lib/opencode-client.ts
@@ -35,6 +35,16 @@ export function getOpencodeBaseUrl(port: number) {
   return `http://${hostname}:${port}`;
 }
 
+function getAuthHeaders(): Record<string, string> | undefined {
+  const username = process.env.OPENCODE_SERVER_USERNAME;
+  const password = process.env.OPENCODE_SERVER_PASSWORD;
+  if (username && password) {
+    return {
+      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+    };
+  }
+}
+
 export function getOpencodeClient(port: number) {
   const baseUrl = getOpencodeBaseUrl(port);
 
@@ -43,8 +53,10 @@ export function getOpencodeClient(port: number) {
     return cached;
   }
 
+  const authHeaders = getAuthHeaders();
   const client = createOpencodeClient({
     baseUrl,
+    ...(authHeaders ? { headers: authHeaders } : {}),
   });
 
   clientCache.set(baseUrl, client);


### PR DESCRIPTION
## Summary

When the OpenCode server runs with Basic Auth enabled (`OPENCODE_SERVER_USERNAME` / `OPENCODE_SERVER_PASSWORD`), Portal fails to discover instances and every backend call fails: the UI shows **"No instances found"** and `/api/opencode/<port>/health` returns `{"healthy":false}`.

Fixes #53

## Root cause

- **Discovery** (`apps/web/src/server/instances.ts`): `probeOpenCode()` calls `GET /global/health` with a plain `fetch` and no `Authorization` header → `401` → instance never discovered.
- **SDK client** (`apps/web/src/server/lib/opencode-client.ts`): `createOpencodeClient({ baseUrl })` is created without credentials, and the SDK does not read `OPENCODE_SERVER_*` from the environment. The generated `authFn` path is never triggered because the OpenAPI operations have no `security` definitions.

## Changes

Read `OPENCODE_SERVER_USERNAME` / `OPENCODE_SERVER_PASSWORD` from the environment and inject a `Basic` `Authorization` header when both are set:

1. `apps/web/src/server/instances.ts` — `getAuthHeaders()` merged into `fetchJson()` headers, so all discovery probes (health, project, session stats) authenticate.
2. `apps/web/src/server/lib/opencode-client.ts` — `getAuthHeaders()` passed as `headers` to `createOpencodeClient()`, which are merged into every request.

When the env vars are absent, behavior is unchanged (no header sent).

## Verification

Tested on Fedora 44 with opencode `1.18.16` and `OPENCODE_SERVER_USERNAME` / `OPENCODE_SERVER_PASSWORD` set:

- `/api/instances` → `total: 1` with the discovered instance (version, project, session stats)
- `/api/opencode/4000/health` → `{"healthy":true,"port":4000}`
- `/api/opencode/4000/sessions` → real session list
- SSE `/api/opencode/4000/events` → stream events
- Direct request to the backend without credentials still returns `401`