### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/apps/docs/app/docs/setup/remote/page.mdx
+++ b/apps/docs/app/docs/setup/remote/page.mdx
@@ -195,3 +195,17 @@ http://myserver:3002  # project-b
 - Portal is only accessible via your Tailscale network
 - No ports need to be exposed to the public internet
 - Consider using [Tailscale ACLs](https://tailscale.com/kb/1018/acls) for additional access control
+
+## Optional: Build Remote Agent spectator
+
+Portal is the full mobile UI over Tailscale. You can **also** pair a second device with [Build Remote Agent](https://grokbuildremote.com/) so a phone spectates (and can veto) without orchestrating. Protocol `gbr/1`. Independent product; not affiliated with xAI or SpaceX.
+
+On the same host that runs Portal + OpenCode:
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Phone: open Build Remote Agent → scan the QR (or type the 8-char code). Attach only at `http://127.0.0.1:8788` (Bot API) or MCP stdio `gbr-mcp` from [GrokBuildRemote-Agents](https://github.com/LinespottingOrg/GrokBuildRemote-Agents). Do not expose `:8788` on the Tailnet unless you intend to; loopback is the supported attach surface. Never put mailbox keys in git.

--- a/apps/docs/app/docs/setup/remote/page.mdx
+++ b/apps/docs/app/docs/setup/remote/page.mdx
@@ -1,5 +1,32 @@
 # Remote Setup
 
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
+
 Access Portal from anywhere by running it on a VPS or home server with Tailscale.
 
 ## Architecture
@@ -202,10 +229,12 @@ Portal is the full mobile UI over Tailscale. You can **also** pair a second devi
 
 On the same host that runs Portal + OpenCode:
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version    # need v0.6.0+
-gbr-agent pair && gbr-agent run
-```
 
 Phone: open Build Remote Agent → scan the QR (or type the 8-char code). Attach only at `http://127.0.0.1:8788` (Bot API) or MCP stdio `gbr-mcp` from [GrokBuildRemote-Agents](https://github.com/LinespottingOrg/GrokBuildRemote-Agents). Do not expose `:8788` on the Tailnet unless you intend to; loopback is the supported attach surface. Never put mailbox keys in git.
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html


### PR DESCRIPTION
Add **Build Remote Agent** as an optional phone pairing device for a desktop session of this project.

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.** Protocol `gbr/1` (existing pair flow only — no new pair protocol).

## Pair

```bash
# macOS / Linux
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version          # need v0.6.0+
gbr-agent pair             # browser QR + printed 8-char code
gbr-agent run              # leave running
```

Phone: open [Build Remote Agent](https://grokbuildremote.com/) → scan QR or type the 8-char code. Unpair in Settings before changing PCs.

## Attach (only these)

- HTTP Bot API: `http://127.0.0.1:8788` after `gbr-agent run`
- MCP stdio: `node …/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js`

```bash
curl -sS http://127.0.0.1:8788/health
curl -sS http://127.0.0.1:8788/v1/sessions
```

Phone is **spectator + veto**, not orchestrator. Never commit mailbox keys.

Agent (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents
