### PR TITLE
Add subagent mention support and group child sessions in dropdown

### DIFF
--- a/apps/web/src/components/file-mention-popover.tsx
+++ b/apps/web/src/components/file-mention-popover.tsx
@@ -3,6 +3,12 @@ import { useEffect, useRef, useState } from "react";
 import useMediaQuery from "@/hooks/use-media-query";
 import { useInstanceStore } from "@/stores/instance-store";
 import { backendBasePath } from "@/lib/backend-url";
+import type { Agent } from "@opencode-ai/sdk/v2";
+import {
+  SubagentMentionRows,
+  subagentResults,
+  type MentionResult,
+} from "@/components/subagent-mention";
 
 interface FileResult {
   path: string;
@@ -98,13 +104,14 @@ function getCaretCoordinates(
 interface FileMentionPopoverProps {
   isOpen: boolean;
   searchQuery: string;
-  onSelect: (filePath: string) => void;
+  onSelect: (value: string) => void;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   mentionStart: number | null;
   selectedIndex: number;
   onSelectedIndexChange: (index: number) => void;
-  onFilesChange?: (files: string[]) => void;
+  onResultsChange?: (results: MentionResult[]) => void;
   onClose: () => void;
+  agents?: Agent[];
 }
 
 export function FileMentionPopover({
@@ -115,8 +122,9 @@ export function FileMentionPopover({
   mentionStart,
   selectedIndex,
   onSelectedIndexChange,
-  onFilesChange,
+  onResultsChange,
   onClose,
+  agents = [],
 }: FileMentionPopoverProps) {
   const [files, setFiles] = useState<FileResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -127,6 +135,9 @@ export function FileMentionPopover({
   const instance = useInstanceStore((s) => s.instance);
   const port = instance?.port;
   const apiBase = port ? backendBasePath(instance?.provider, port) : "";
+
+  const agentResults = subagentResults(agents, searchQuery);
+  const totalResults = agentResults.length + files.length;
 
   useEffect(() => {
     if (isOpen && mentionStart !== null && textareaRef.current) {
@@ -154,7 +165,7 @@ export function FileMentionPopover({
   useEffect(() => {
     if (!isOpen || !searchQuery || !port) {
       setFiles([]);
-      onFilesChange?.([]);
+      onResultsChange?.(subagentResults(agents, searchQuery));
       return;
     }
 
@@ -174,7 +185,10 @@ export function FileMentionPopover({
             name: path.split("/").pop() || path,
           }));
           setFiles(mappedFiles);
-          onFilesChange?.(mappedFiles.map((f) => f.path));
+          onResultsChange?.([
+            ...subagentResults(agents, searchQuery),
+            ...mappedFiles.map((f) => ({ type: "file" as const, value: f.path })),
+          ]);
         }
       } catch (err) {
         if ((err as Error).name !== "AbortError") {
@@ -190,10 +204,11 @@ export function FileMentionPopover({
       clearTimeout(debounceTimer);
       controller.abort();
     };
-  }, [isOpen, searchQuery, port, apiBase, onFilesChange]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, searchQuery, port, apiBase, agents, onResultsChange]);
 
   useEffect(() => {
-    if (listRef.current && files.length > 0) {
+    if (listRef.current && totalResults > 0) {
       const selectedElement = listRef.current.children[
         selectedIndex
       ] as HTMLElement;
@@ -201,7 +216,7 @@ export function FileMentionPopover({
         selectedElement.scrollIntoView({ block: "nearest" });
       }
     }
-  }, [selectedIndex, files.length]);
+  }, [selectedIndex, totalResults]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -225,6 +240,65 @@ export function FileMentionPopover({
     };
   }, [isOpen, onClose, textareaRef]);
 
+  const renderRows = (hoverClassName: string) => (
+    <>
+      <SubagentMentionRows
+        agents={agents}
+        query={searchQuery}
+        selectedIndex={selectedIndex}
+        onSelect={onSelect}
+        onSelectedIndexChange={onSelectedIndexChange}
+      />
+
+      {agentResults.length > 0 && files.length > 0 && (
+        <div className="px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-muted-fg/60">
+          Files
+        </div>
+      )}
+
+      {files.map((file, index) => {
+        const absIndex = agentResults.length + index;
+        const isSelected = absIndex === selectedIndex;
+        return (
+          <button
+            type="button"
+            key={file.path}
+            className={`flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left text-sm transition-all duration-150 ${
+              isSelected ? "bg-primary/10 text-primary-fg" : hoverClassName
+            }`}
+            onClick={() => onSelect(file.path)}
+            onMouseEnter={() => onSelectedIndexChange(absIndex)}
+            onTouchEnd={() => onSelect(file.path)}
+          >
+            <div
+              className={`flex shrink-0 items-center justify-center rounded-md p-1.5 ${
+                isSelected ? "bg-primary text-primary-fg" : "bg-muted text-muted-fg"
+              }`}
+            >
+              <DocumentIcon className="size-4" />
+            </div>
+            <div className="flex flex-col min-w-0 flex-1">
+              <span
+                className={`font-medium truncate leading-tight ${
+                  isSelected ? "text-primary-fg" : "text-foreground"
+                }`}
+              >
+                {file.name}
+              </span>
+              <span
+                className={`text-[10px] truncate leading-tight ${
+                  isSelected ? "text-primary-fg/70" : "text-muted-fg/70"
+                }`}
+              >
+                {file.path}
+              </span>
+            </div>
+          </button>
+        );
+      })}
+    </>
+  );
+
   if (!isOpen) return null;
   if (!isMobile && !position) return null;
 
@@ -235,60 +309,20 @@ export function FileMentionPopover({
         className="absolute bottom-full left-5 right-5 mb-3 z-50 rounded-xl border border-border/50 bg-background/95 backdrop-blur-xl shadow-2xl animate-in fade-in slide-in-from-bottom-2 duration-200"
       >
         <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-muted-fg/80 border-b border-border/40 bg-muted/20 rounded-t-xl">
-          {loading ? "Searching..." : `Files matching "${searchQuery}"`}
+          {loading ? "Searching..." : `Matching "${searchQuery}"`}
         </div>
         <div
           ref={listRef}
           className="max-h-56 overflow-y-auto p-1.5 scrollbar-hide"
         >
-          {files.length === 0 && !loading && (
+          {totalResults === 0 && (
             <div className="px-3 py-4 text-center text-sm text-muted-fg/60">
-              No files found
+              {loading ? "Searching..." : "No matching agents or files"}
             </div>
           )}
-          {files.map((file, index) => (
-            <button
-              type="button"
-              key={file.path}
-              className={`flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left text-sm transition-all duration-150 ${
-                index === selectedIndex
-                  ? "bg-primary/10 text-primary-fg"
-                  : "hover:bg-muted/50 active:bg-muted/70 text-foreground"
-              }`}
-              onClick={() => onSelect(file.path)}
-              onTouchEnd={() => onSelect(file.path)}
-            >
-              <div
-                className={`flex shrink-0 items-center justify-center rounded-md p-1.5 ${
-                  index === selectedIndex
-                    ? "bg-primary text-primary-fg"
-                    : "bg-muted text-muted-fg"
-                }`}
-              >
-                <DocumentIcon className="size-4" />
-              </div>
-              <div className="flex flex-col min-w-0 flex-1">
-                <span
-                  className={`font-medium truncate leading-tight ${
-                    index === selectedIndex
-                      ? "text-primary-fg"
-                      : "text-foreground"
-                  }`}
-                >
-                  {file.name}
-                </span>
-                <span
-                  className={`text-[10px] truncate leading-tight ${
-                    index === selectedIndex
-                      ? "text-primary-fg/70"
-                      : "text-muted-fg/70"
-                  }`}
-                >
-                  {file.path}
-                </span>
-              </div>
-            </button>
-          ))}
+          {renderRows(
+            "hover:bg-muted/50 active:bg-muted/70 text-foreground",
+          )}
         </div>
       </div>
     );
@@ -307,64 +341,24 @@ export function FileMentionPopover({
       style={desktopStyle}
     >
       <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-muted-fg/80 border-b border-border/40 bg-muted/20 rounded-t-xl">
-        {loading ? "Searching..." : `Files matching "${searchQuery}"`}
+        {loading ? "Searching..." : `Matching "${searchQuery}"`}
       </div>
       <div
         ref={listRef}
         className="max-h-[300px] overflow-y-auto p-1.5 scrollbar-thin scrollbar-thumb-border/50 scrollbar-track-transparent"
       >
-        {files.length === 0 && !loading && (
+        {totalResults === 0 && (
           <div className="px-3 py-4 text-center text-sm text-muted-fg/60">
-            No files found
+            {loading ? "Searching..." : "No matching agents or files"}
           </div>
         )}
-        {files.map((file, index) => (
-          <button
-            type="button"
-            key={file.path}
-            className={`flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left text-sm transition-all duration-150 ${
-              index === selectedIndex
-                ? "bg-primary/10 text-primary-fg"
-                : "hover:bg-muted/50 text-foreground"
-            }`}
-            onClick={() => onSelect(file.path)}
-            onMouseEnter={() => onSelectedIndexChange(index)}
-          >
-            <div
-              className={`flex shrink-0 items-center justify-center rounded-md p-1.5 ${
-                index === selectedIndex
-                  ? "bg-primary text-primary-fg"
-                  : "bg-muted text-muted-fg"
-              }`}
-            >
-              <DocumentIcon className="size-4" />
-            </div>
-            <div className="flex flex-col min-w-0 flex-1">
-              <span
-                className={`font-medium truncate leading-tight ${
-                  index === selectedIndex
-                    ? "text-primary-fg"
-                    : "text-foreground"
-                }`}
-              >
-                {file.name}
-              </span>
-              <span
-                className={`text-[10px] truncate leading-tight ${
-                  index === selectedIndex
-                    ? "text-primary-fg/70"
-                    : "text-muted-fg/70"
-                }`}
-              >
-                {file.path}
-              </span>
-            </div>
-          </button>
-        ))}
+{renderRows(
+            "hover:bg-muted/50 text-foreground",
+          )}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
 
 interface UseMentionResult {
   isOpen: boolean;
@@ -372,8 +366,8 @@ interface UseMentionResult {
   selectedIndex: number;
   mentionStart: number | null;
   handleInputChange: (value: string, cursorPosition: number) => void;
-  handleKeyDown: (e: React.KeyboardEvent, filesCount: number) => boolean;
-  handleSelect: (filePath: string, currentValue: string) => string;
+  handleKeyDown: (e: React.KeyboardEvent, resultsCount: number) => boolean;
+  handleSelect: (value: string, currentValue: string) => string;
   close: () => void;
   setSelectedIndex: (index: number) => void;
 }
@@ -410,19 +404,19 @@ export function useFileMention(): UseMentionResult {
 
   const handleKeyDown = (
     e: React.KeyboardEvent,
-    filesCount: number,
+    resultsCount: number,
   ): boolean => {
     if (!isOpen) return false;
 
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();
-        setSelectedIndex((prev) => (prev + 1) % Math.max(filesCount, 1));
+        setSelectedIndex((prev) => (prev + 1) % Math.max(resultsCount, 1));
         return true;
       case "ArrowUp":
         e.preventDefault();
         setSelectedIndex((prev) =>
-          prev - 1 < 0 ? Math.max(filesCount - 1, 0) : prev - 1,
+          prev - 1 < 0 ? Math.max(resultsCount - 1, 0) : prev - 1,
         );
         return true;
       case "Escape":
@@ -431,7 +425,7 @@ export function useFileMention(): UseMentionResult {
         return true;
       case "Tab":
       case "Enter":
-        if (filesCount > 0) {
+        if (resultsCount > 0) {
           e.preventDefault();
           return true;
         }
@@ -441,14 +435,14 @@ export function useFileMention(): UseMentionResult {
     }
   };
 
-  const handleSelect = (filePath: string, currentValue: string): string => {
+  const handleSelect = (value: string, currentValue: string): string => {
     if (mentionStart === null) return currentValue;
 
     const beforeMention = currentValue.slice(0, mentionStart);
     const afterMention = currentValue.slice(
       mentionStart + 1 + searchQuery.length,
     );
-    const newValue = `${beforeMention}@${filePath} ${afterMention}`;
+    const newValue = `${beforeMention}@${value} ${afterMention}`;
 
     close();
     return newValue;

--- a/apps/web/src/components/subagent-mention.tsx
+++ b/apps/web/src/components/subagent-mention.tsx
@@ -1,0 +1,87 @@
+import { IconBadgeSparkle } from "@/components/icons/lucide";
+import { searchSubagents } from "@/lib/agent-selection";
+import type { Agent } from "@opencode-ai/sdk/v2";
+
+export interface MentionResult {
+  type: "agent" | "file";
+  value: string;
+}
+
+interface SubagentMentionProps {
+  agents: Agent[];
+  query: string;
+  selectedIndex: number;
+  onSelect: (name: string) => void;
+  onSelectedIndexChange: (index: number) => void;
+}
+
+export function SubagentMentionRows({
+  agents,
+  query,
+  selectedIndex,
+  onSelect,
+  onSelectedIndexChange,
+}: SubagentMentionProps) {
+  const results = searchSubagents(agents, query);
+
+  if (results.length === 0) return null;
+
+  return (
+    <>
+      {results.map((agent, index) => (
+        <button
+          type="button"
+          key={`agent-${agent.name}`}
+          className={`flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left text-sm transition-all duration-150 ${
+            index === selectedIndex
+              ? "bg-primary/10 text-primary-fg"
+              : "hover:bg-muted/50 active:bg-muted/70 text-foreground"
+          }`}
+          onMouseEnter={() => onSelectedIndexChange(index)}
+          onClick={() => onSelect(agent.name)}
+          onTouchEnd={() => onSelect(agent.name)}
+        >
+          <div
+            className={`flex shrink-0 items-center justify-center rounded-md p-1.5 ${
+              index === selectedIndex
+                ? "bg-primary text-primary-fg"
+                : "bg-[color-mix(in_oklab,var(--color-primary)_20%,var(--color-muted))] text-primary"
+            }`}
+          >
+            <IconBadgeSparkle className="size-4" />
+          </div>
+          <div className="flex flex-col min-w-0 flex-1">
+            <span
+              className={`font-medium truncate leading-tight ${
+                index === selectedIndex
+                  ? "text-primary-fg"
+                  : "text-foreground"
+              }`}
+            >
+              @{agent.name}
+            </span>
+            <span
+              className={`text-[10px] truncate leading-tight ${
+                index === selectedIndex
+                  ? "text-primary-fg/70"
+                  : "text-muted-fg/70"
+              }`}
+            >
+              {agent.description || "Subagent"}
+            </span>
+          </div>
+        </button>
+      ))}
+    </>
+  );
+}
+
+export function subagentResults(
+  agents: Agent[],
+  query: string,
+): MentionResult[] {
+  return searchSubagents(agents, query).map((agent) => ({
+    type: "agent",
+    value: agent.name,
+  }));
+}

--- a/apps/web/src/hooks/use-opencode.ts
+++ b/apps/web/src/hooks/use-opencode.ts
@@ -52,6 +52,15 @@ export function useSessionMessages(id: string | null) {
   );
 }
 
+export function useSessionChildren(id: string | null) {
+  const backend = useBackend();
+
+  return useSWR(
+    backend && id ? `${backend.basePath}/session/${id}/children` : null,
+    fetcher,
+  );
+}
+
 export function useSessionStatuses() {
   const backend = useBackend();
 

--- a/apps/web/src/lib/agent-selection.ts
+++ b/apps/web/src/lib/agent-selection.ts
@@ -22,3 +22,37 @@ export function isValidUserSelectableAgent(agents: Agent[], name?: string) {
 export function getDefaultUserSelectableAgentName(agents: Agent[]) {
   return userSelectableAgents(agents)[0]?.name;
 }
+
+export function subagents(agents: Agent[]) {
+  const items = agents as AgentSelectionMetadata[];
+  return items.filter((agent) => agent.mode === "subagent");
+}
+
+const MENTION_REGEX = /@([\w.-]+)/g;
+
+// Extract the subagent names referenced in a message via `@name`, filtered
+// to agents that are actually subagents.
+export function extractSubagentMentions(
+  text: string,
+  agents: Agent[],
+): string[] {
+  const subagentNames = new Set(subagents(agents).map((agent) => agent.name));
+  const mentions: string[] = [];
+
+  for (const match of text.matchAll(MENTION_REGEX)) {
+    const name = match[1];
+    if (subagentNames.has(name)) {
+      mentions.push(name);
+    }
+  }
+
+  return Array.from(new Set(mentions));
+}
+
+// Return subagents whose name matches the `@` query for the mention popover.
+export function searchSubagents(agents: Agent[], query: string) {
+  const q = query.trim().toLowerCase();
+  return subagents(agents).filter(
+    (agent) => !q || agent.name.toLowerCase().includes(q),
+  );
+}

--- a/apps/web/src/routes/_app/session/$id.tsx
+++ b/apps/web/src/routes/_app/session/$id.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState, useCallback, useMemo, memo } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -8,6 +8,15 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Loader } from "@/components/ui/loader";
+import {
+  Menu,
+  MenuContent,
+  MenuHeader,
+  MenuItem,
+  MenuSection,
+  MenuTrigger,
+} from "@/components/ui/menu";
+import type { SessionStatus } from "@opencode-ai/sdk/v2";
 import { AgentSelect } from "@/components/agent-select";
 import { ModelSelect } from "@/components/model-select";
 import {
@@ -23,6 +32,7 @@ import {
   IconUser,
   InformationCircleIcon,
   SendIcon,
+  ChevronDownIcon,
 } from "@/components/icons/lucide";
 import { useAgentStore } from "@/stores/agent-store";
 import { useInstanceStore } from "@/stores/instance-store";
@@ -47,12 +57,14 @@ import {
   useAgents,
   usePermissions,
   useQuestions,
+  useSessionChildren,
   useSessionStatuses,
   useSessions,
 } from "@/hooks/use-opencode";
 import {
   getDefaultUserSelectableAgentName,
   isValidUserSelectableAgent,
+  extractSubagentMentions,
 } from "@/lib/agent-selection";
 import { getErrorMessage, getResponseErrorMessage } from "@/lib/error-message";
 import { backendBasePath, type BackendProvider } from "@/lib/backend-url";
@@ -808,6 +820,7 @@ function hasVisibleContent(message: MessageWithParts): boolean {
 function SessionPage() {
   const { id: sessionId } = Route.useParams();
   const instance = useInstanceStore((s) => s.instance);
+  const navigate = useNavigate();
   const port = instance?.port ?? 0;
   const provider = instance?.provider;
   const supportsAgentSelection = provider === "opencode";
@@ -820,6 +833,7 @@ function SessionPage() {
     error: messagesError,
   } = useSessionMessages(sessionId);
   const { data: sessionsData, mutate: mutateSessions } = useSessions();
+  const { data: childrenData } = useSessionChildren(sessionId);
   const { data: agentsData } = useAgents();
   const { data: sessionStatusesData, mutate: mutateSessionStatuses } =
     useSessionStatuses();
@@ -833,6 +847,7 @@ function SessionPage() {
   const sessions: Session[] = sessionsData ?? [];
   const agents: Agent[] = agentsData ?? [];
   const currentSession = sessions.find((s) => s.id === sessionId);
+  const childSessions: Session[] = childrenData ?? [];
 
   useEffect(() => {
     if (currentSession?.title) {
@@ -862,7 +877,9 @@ function SessionPage() {
   const [input, setInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasScrolledInitially, setHasScrolledInitially] = useState(false);
-  const [fileResults, setFileResults] = useState<string[]>([]);
+  const [mentionResults, setMentionResults] = useState<
+    { type: "agent" | "file"; value: string }[]
+  >([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -1025,6 +1042,7 @@ function SessionPage() {
           body: JSON.stringify({
             messageID: messageId,
             text: messageText,
+            subagents: extractSubagentMentions(messageText, agents),
             model:
               selectedModel.providerID && selectedModel.modelID
                 ? selectedModel
@@ -1146,6 +1164,41 @@ function SessionPage() {
 
   return (
     <div className="flex h-full flex-col -m-4">
+      {childSessions.length > 0 && (
+        <div className="flex items-center gap-2 px-6 py-3 shrink-0 border-b border-dashed border-border">
+          <Menu>
+            <MenuTrigger
+              aria-label="Subagent sessions"
+              className="flex items-center gap-1.5 text-sm text-muted-fg hover:text-fg outline-hidden rounded-md px-2 py-1 hover:bg-muted"
+            >
+              <span className="flex size-2 rounded-full bg-primary" />
+              Subagents
+              <ChevronDownIcon className="size-3.5" />
+            </MenuTrigger>
+            <MenuContent>
+              <MenuSection>
+                <MenuHeader separator>
+                  Subagent sessions ({childSessions.length})
+                </MenuHeader>
+                {childSessions.map((child) => (
+                  <MenuItem
+                    key={child.id}
+                    onAction={() =>
+                      navigate({
+                        to: "/session/$id",
+                        params: { id: child.id },
+                      })
+                    }
+                  >
+                    <span className="size-2 rounded-full bg-muted-fg" />
+                    {child.title || child.id}
+                  </MenuItem>
+                ))}
+              </MenuSection>
+            </MenuContent>
+          </Menu>
+        </div>
+      )}
       <div
         className="flex-1 overflow-auto overflow-x-hidden"
         ref={chatContainerRef}
@@ -1218,10 +1271,11 @@ function SessionPage() {
           mentionStart={fileMention.mentionStart}
           selectedIndex={fileMention.selectedIndex}
           onSelectedIndexChange={fileMention.setSelectedIndex}
-          onFilesChange={setFileResults}
+          onResultsChange={setMentionResults}
           onClose={fileMention.close}
-          onSelect={(filePath) => {
-            const newValue = fileMention.handleSelect(filePath, input);
+          agents={agents}
+          onSelect={(value) => {
+            const newValue = fileMention.handleSelect(value, input);
             setInput(newValue);
           }}
         />
@@ -1263,17 +1317,17 @@ function SessionPage() {
               onKeyDown={(e) => {
                 const handled = fileMention.handleKeyDown(
                   e,
-                  fileResults.length,
+                  mentionResults.length,
                 );
                 if (handled) {
                   if (
                     (e.key === "Enter" || e.key === "Tab") &&
-                    fileResults.length > 0
+                    mentionResults.length > 0
                   ) {
-                    const selectedFile = fileResults[fileMention.selectedIndex];
-                    if (selectedFile) {
+                    const selected = mentionResults[fileMention.selectedIndex];
+                    if (selected) {
                       const newValue = fileMention.handleSelect(
-                        selectedFile,
+                        selected.value,
                         input,
                       );
                       setInput(newValue);
@@ -1288,7 +1342,7 @@ function SessionPage() {
                   }
                 }
               }}
-              placeholder="Type your message... (use @ to mention files)"
+              placeholder="Type your message... (use @ to mention files or subagents)"
               className="min-h-32 max-h-32 w-full resize-none overflow-y-auto pr-14 pb-12"
               rows={5}
             />

--- a/apps/web/src/server/opencode/[port]/session/[id]/children.ts
+++ b/apps/web/src/server/opencode/[port]/session/[id]/children.ts
@@ -1,0 +1,13 @@
+import { defineHandler } from "nitro/h3";
+import { getOpencodeClient } from "../../../../lib/opencode-client";
+import { parsePort, parseRouteParam } from "../../../../lib/validation";
+
+export default defineHandler(async (event) => {
+  const port = parsePort(event);
+  const id = parseRouteParam(event, "id");
+
+  const client = getOpencodeClient(port);
+  const children = await client.session.children({ sessionID: id });
+
+  return children.data ?? [];
+});

--- a/apps/web/src/server/opencode/[port]/session/[id]/prompt.ts
+++ b/apps/web/src/server/opencode/[port]/session/[id]/prompt.ts
@@ -22,7 +22,50 @@ const promptBodySchema = z.object({
     })
     .optional(),
   agent: z.string().optional(),
+  subagents: z.array(z.string()).default([]),
 });
+
+type AgentPartInput = { type: "agent"; name: string };
+type TextPartInput = { type: "text"; text: string };
+type PromptPart = AgentPartInput | TextPartInput;
+
+// Build a prompt `parts` array that turns `@subagent` mentions into
+// OpenCode agent parts. Text segments and agent mentions are emitted in
+// document order so the subagent is actually delegated work.
+function buildPromptParts(
+  text: string,
+  subagentNames: string[],
+): PromptPart[] {
+  if (subagentNames.length === 0) {
+    return [{ type: "text", text }];
+  }
+
+  const escaped = subagentNames
+    .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .sort((a, b) => b.length - a.length)
+    .join("|");
+  const mentionRegex = new RegExp(`@(${escaped})\\b`, "g");
+
+  const parts: PromptPart[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = mentionRegex.exec(text)) !== null) {
+    const before = text.slice(lastIndex, match.index);
+    if (before) {
+      parts.push({ type: "text", text: before });
+    }
+    parts.push({ type: "agent", name: match[1] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  const remaining = text.slice(lastIndex);
+  if (remaining) {
+    parts.push({ type: "text", text: remaining });
+  }
+
+  return parts.length > 0 ? parts : [{ type: "text", text }];
+}
 
 function prunePromptRequests(now: number) {
   for (const [key, expiresAt] of recentPromptRequests) {
@@ -64,10 +107,33 @@ export default defineHandler(async (event) => {
 
   const client = getOpencodeClient(port);
   try {
+    const requestedSubagents = Array.from(
+      new Set(body.subagents.map((name) => name.trim()).filter(Boolean)),
+    );
+
+    const agentNames = new Set<string>();
+    if (requestedSubagents.length > 0) {
+      try {
+        const agentList = await client.app.agents();
+        for (const agent of agentList.data ?? []) {
+          if (agent.mode === "subagent") {
+            agentNames.add(agent.name);
+          }
+        }
+      } catch {
+        // If we can't resolve the agent list, fall back to sending the
+        // mention in text only.
+      }
+    }
+
+    const mentionable = requestedSubagents.filter((name) =>
+      agentNames.has(name),
+    );
+
     const promptInput = {
       sessionID: id,
       messageID: body.messageID,
-      parts: [{ type: "text" as const, text: body.text }],
+      parts: buildPromptParts(body.text, mentionable),
       model: body.model
         ? {
             providerID: body.model.providerID,


### PR DESCRIPTION
## Subagent Mentions & Delegation via `@`

This PR lets users delegate tasks to their existing subagents from the portal chat by mentioning
them with `@name`. It also groups a session's running subagent child-sessions into a dropdown on the
session page so you can jump straight into a subagent's own conversation.

### What's included

**Mention & delegate**
- Typing `@name` in the chat now surfaces a popover listing matching **subagents and files**, just
  like the existing file mentions.
- Selecting a subagent sends its name through to the prompt as an OpenCode **agent part**, so the
  task is actually delegated to that subagent — not just mentioned in text.
- Server-side validation whitelists mentions against the actual `subagent`-mode agents, with a safe
  fallback to plain text if agent resolution fails.

**Group subagent sessions**
- Added `/session/{id}/children` so the portal can read a session's child (subagent) sessions.
- A new **Subagents dropdown** on the session page lists those child sessions; pick one to open that
  subagent's conversation in the same chat view.

### Includes
- **New:** `subagent-mention.tsx` (isolated subagent mention rows/helpers),
  `session/{id}/children.ts` (children route)
- **Updated:** `file-mention-popover`, `$id.tsx`, `prompt.ts`, `agent-selection.ts`, `use-opencode.ts`
- **Verified:** `tsc --noEmit` and `vite build`